### PR TITLE
Add controller texture config option to profiles

### DIFF
--- a/Editor/Utilities/ControllerMappingUtilities.cs
+++ b/Editor/Utilities/ControllerMappingUtilities.cs
@@ -99,7 +99,12 @@ namespace XRTK.Editor.Utilities
             }
 
             texture = GetControllerTextureInternal(mappingProfile, scaled);
-            CachedTextures.Add(key, texture);
+
+            if (texture.IsNotNull())
+            {
+                CachedTextures.Add(key, texture);
+            }
+
             return texture;
         }
 

--- a/Editor/Utilities/ControllerMappingUtilities.cs
+++ b/Editor/Utilities/ControllerMappingUtilities.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using XRTK.Definitions.Controllers;
 using XRTK.Definitions.Devices;
 using XRTK.Definitions.Utilities;
+using XRTK.Extensions;
 
 namespace XRTK.Editor.Utilities
 {
@@ -71,10 +72,7 @@ namespace XRTK.Editor.Utilities
         /// The file name should be formatted as:<para/>XRTK/StandardAssets/Textures/{ControllerTypeName}_{handedness}_{theme}_{scaled}.png<para/>
         /// scaled suffix is optional.<para/>
         /// </remarks>
-        public static Texture2D GetControllerTexture(MixedRealityControllerMappingProfile mappingProfile)
-        {
-            return GetControllerTextureCached(mappingProfile);
-        }
+        public static Texture2D GetControllerTexture(MixedRealityControllerMappingProfile mappingProfile) => GetControllerTextureCached(mappingProfile);
 
         /// <summary>
         /// Gets a texture based on the <see cref="MixedRealityControllerMappingProfile"/>.
@@ -84,13 +82,15 @@ namespace XRTK.Editor.Utilities
         /// <remarks>
         /// The file name should be formatted as:<para/>XRTK/StandardAssets/Textures/{ControllerName}_{handedness}_{theme}_{scaled}.png<para/>
         /// </remarks>
-        public static Texture2D GetControllerTextureScaled(MixedRealityControllerMappingProfile mappingProfile)
-        {
-            return GetControllerTextureCached(mappingProfile, true);
-        }
+        public static Texture2D GetControllerTextureScaled(MixedRealityControllerMappingProfile mappingProfile) => GetControllerTextureCached(mappingProfile, true);
 
         private static Texture2D GetControllerTextureCached(MixedRealityControllerMappingProfile mappingProfile, bool scaled = false)
         {
+            if (TryGetControllerTextureFromProfile(mappingProfile, scaled, out var profileTexture))
+            {
+                return profileTexture;
+            }
+
             var key = new Tuple<Type, Handedness, bool>(mappingProfile.ControllerType.Type, mappingProfile.Handedness, scaled);
 
             if (CachedTextures.TryGetValue(key, out var texture))
@@ -154,6 +154,47 @@ namespace XRTK.Editor.Utilities
             var themeSuffix = EditorGUIUtility.isProSkin ? "_white" : "_black";
 
             return (Texture2D)AssetDatabase.LoadAssetAtPath($"{fullTexturePath}{handednessSuffix}{themeSuffix}{(scaled ? "_scaled" : string.Empty)}.png", typeof(Texture2D));
+        }
+
+        private static bool TryGetControllerTextureFromProfile(MixedRealityControllerMappingProfile mappingProfile, bool scaled, out Texture2D texture)
+        {
+            texture = null;
+
+            if (mappingProfile.Handedness == Handedness.Left && scaled && EditorGUIUtility.isProSkin)
+            {
+                texture = mappingProfile.DarkThemeLeftControllerTextureScaled;
+            }
+            else if (mappingProfile.Handedness == Handedness.Left && scaled && !EditorGUIUtility.isProSkin)
+            {
+                texture = mappingProfile.LightThemeLeftControllerTextureScaled;
+            }
+            else if (mappingProfile.Handedness == Handedness.Left && !scaled && EditorGUIUtility.isProSkin)
+            {
+                texture = mappingProfile.DarkThemeLeftControllerTexture;
+            }
+            else if (mappingProfile.Handedness == Handedness.Left && !scaled && !EditorGUIUtility.isProSkin)
+            {
+                texture = mappingProfile.LightThemeLeftControllerTexture;
+            }
+            // We use the right controller texture for anything that is not left handedness.
+            else if (scaled && EditorGUIUtility.isProSkin)
+            {
+                texture = mappingProfile.DarkThemeRightControllerTextureScaled;
+            }
+            else if (scaled && !EditorGUIUtility.isProSkin)
+            {
+                texture = mappingProfile.LightThemeRightControllerTextureScaled;
+            }
+            else if (!scaled && EditorGUIUtility.isProSkin)
+            {
+                texture = mappingProfile.DarkThemeRightControllerTexture;
+            }
+            else if (!scaled && !EditorGUIUtility.isProSkin)
+            {
+                texture = mappingProfile.LightThemeRightControllerTexture;
+            }
+
+            return texture.IsNotNull();
         }
 
         #endregion Controller Texture Loading

--- a/Runtime/Definitions/Controllers/MixedRealityControllerMappingProfile.cs
+++ b/Runtime/Definitions/Controllers/MixedRealityControllerMappingProfile.cs
@@ -67,42 +67,74 @@ namespace XRTK.Definitions.Controllers
         [SerializeField]
         private Texture2D lightThemeLeftControllerTexture = null;
 
-        public Texture2D LightThemeLeftControllerTexture => lightThemeLeftControllerTexture;
+        public Texture2D LightThemeLeftControllerTexture
+        {
+            get => lightThemeLeftControllerTexture;
+            internal set => lightThemeLeftControllerTexture = value;
+        }
 
         [SerializeField]
         private Texture2D lightThemeLeftControllerTextureScaled = null;
 
-        public Texture2D LightThemeLeftControllerTextureScaled => lightThemeLeftControllerTextureScaled;
+        public Texture2D LightThemeLeftControllerTextureScaled
+        {
+            get => lightThemeLeftControllerTextureScaled;
+            internal set => lightThemeLeftControllerTextureScaled = value;
+        }
 
         [SerializeField]
         private Texture2D darkThemeLeftControllerTexture = null;
 
-        public Texture2D DarkThemeLeftControllerTexture => darkThemeLeftControllerTexture;
+        public Texture2D DarkThemeLeftControllerTexture
+        {
+            get => darkThemeLeftControllerTexture;
+            internal set => darkThemeLeftControllerTexture = value;
+        }
 
         [SerializeField]
         private Texture2D darkThemeLeftControllerTextureScaled = null;
 
-        public Texture2D DarkThemeLeftControllerTextureScaled => darkThemeLeftControllerTextureScaled;
+        public Texture2D DarkThemeLeftControllerTextureScaled
+        {
+            get => darkThemeLeftControllerTextureScaled;
+            internal set => darkThemeLeftControllerTextureScaled = value;
+        }
 
         [SerializeField]
         private Texture2D lightThemeRightControllerTexture = null;
 
-        public Texture2D LightThemeRightControllerTexture => lightThemeRightControllerTexture;
+        public Texture2D LightThemeRightControllerTexture
+        {
+            get => lightThemeRightControllerTexture;
+            internal set => lightThemeRightControllerTexture = value;
+        }
 
         [SerializeField]
         private Texture2D lightThemeRightControllerTextureScaled = null;
 
-        public Texture2D LightThemeRightControllerTextureScaled => lightThemeRightControllerTextureScaled;
+        public Texture2D LightThemeRightControllerTextureScaled
+        {
+            get => lightThemeRightControllerTextureScaled;
+            internal set => lightThemeRightControllerTextureScaled = value;
+        }
 
         [SerializeField]
         private Texture2D darkThemeRightControllerTexture = null;
 
-        public Texture2D DarkThemeRightControllerTexture => darkThemeRightControllerTexture;
+        public Texture2D DarkThemeRightControllerTexture
+        {
+            get => darkThemeRightControllerTexture;
+            internal set => darkThemeRightControllerTexture = value;
+        }
 
         [SerializeField]
         private Texture2D darkThemeRightControllerTextureScaled = null;
 
-        public Texture2D DarkThemeRightControllerTextureScaled => darkThemeRightControllerTextureScaled;
+        public Texture2D DarkThemeRightControllerTextureScaled
+        {
+            get => darkThemeRightControllerTextureScaled;
+            internal set => darkThemeRightControllerTextureScaled = value;
+        }
 
         #endregion
     }

--- a/Runtime/Definitions/Controllers/MixedRealityControllerMappingProfile.cs
+++ b/Runtime/Definitions/Controllers/MixedRealityControllerMappingProfile.cs
@@ -61,5 +61,49 @@ namespace XRTK.Definitions.Controllers
             get => interactionMappingProfiles;
             internal set => interactionMappingProfiles = value;
         }
+
+        #region Fields hidden in non-debug inspector
+
+        [SerializeField]
+        private Texture2D lightThemeLeftControllerTexture = null;
+
+        public Texture2D LightThemeLeftControllerTexture => lightThemeLeftControllerTexture;
+
+        [SerializeField]
+        private Texture2D lightThemeLeftControllerTextureScaled = null;
+
+        public Texture2D LightThemeLeftControllerTextureScaled => lightThemeLeftControllerTextureScaled;
+
+        [SerializeField]
+        private Texture2D darkThemeLeftControllerTexture = null;
+
+        public Texture2D DarkThemeLeftControllerTexture => darkThemeLeftControllerTexture;
+
+        [SerializeField]
+        private Texture2D darkThemeLeftControllerTextureScaled = null;
+
+        public Texture2D DarkThemeLeftControllerTextureScaled => darkThemeLeftControllerTextureScaled;
+
+        [SerializeField]
+        private Texture2D lightThemeRightControllerTexture = null;
+
+        public Texture2D LightThemeRightControllerTexture => lightThemeRightControllerTexture;
+
+        [SerializeField]
+        private Texture2D lightThemeRightControllerTextureScaled = null;
+
+        public Texture2D LightThemeRightControllerTextureScaled => lightThemeRightControllerTextureScaled;
+
+        [SerializeField]
+        private Texture2D darkThemeRightControllerTexture = null;
+
+        public Texture2D DarkThemeRightControllerTexture => darkThemeRightControllerTexture;
+
+        [SerializeField]
+        private Texture2D darkThemeRightControllerTextureScaled = null;
+
+        public Texture2D DarkThemeRightControllerTextureScaled => darkThemeRightControllerTextureScaled;
+
+        #endregion
     }
 }

--- a/Tests/Core/TestFixture_02_MixedRealityToolkitUtilityTests.cs
+++ b/Tests/Core/TestFixture_02_MixedRealityToolkitUtilityTests.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Generic;
 using NUnit.Framework;
+using System.Collections.Generic;
 using UnityEngine;
 using XRTK.Definitions;
+using XRTK.Definitions.Controllers;
 using XRTK.Definitions.Controllers.UnityInput.Profiles;
 using XRTK.Definitions.Platforms;
+using XRTK.Editor.Utilities;
 using XRTK.Extensions;
 using XRTK.Interfaces;
 using XRTK.Providers.Controllers.OpenVR;
@@ -23,8 +25,6 @@ namespace XRTK.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitScene(false);
             MixedRealityToolkit.Instance.ActiveProfile.RegisteredServiceProvidersProfile = ScriptableObject.CreateInstance<MixedRealityRegisteredServiceProvidersProfile>();
         }
-
-        #region Configuration Validation Tests
 
         private readonly List<IMixedRealityPlatform> testPlatforms = new List<IMixedRealityPlatform> { new EditorPlatform(), new WindowsStandalonePlatform() };
 
@@ -67,6 +67,58 @@ namespace XRTK.Tests.Core
             Assert.IsFalse(controllerDataMappingProfile.ValidateControllerProfiles(controllerTypes, false));
         }
 
-        #endregion Configuration Validation Tests
+        [Test]
+        public void Test_04_ConfirmGenereicControllerTextureExists()
+        {
+            var controllerMappingProfile = ScriptableObject.CreateInstance<MixedRealityControllerMappingProfile>();
+            controllerMappingProfile.ControllerType = typeof(GenericOpenVRController);
+
+            // Right / Any hand textures
+            controllerMappingProfile.Handedness = Definitions.Utilities.Handedness.Right;
+            var controllerTexture = ControllerMappingUtilities.GetControllerTexture(controllerMappingProfile);
+            Assert.IsNull(controllerTexture); // For generic controllers we expect non-scaled texture to not exist.
+            controllerTexture = ControllerMappingUtilities.GetControllerTextureScaled(controllerMappingProfile);
+            Assert.IsNotNull(controllerTexture);
+
+            // Left hand textures
+            controllerMappingProfile.Handedness = Definitions.Utilities.Handedness.Left;
+            controllerTexture = ControllerMappingUtilities.GetControllerTexture(controllerMappingProfile);
+            Assert.IsNull(controllerTexture); // For generic controllers we expect non-scaled texture to not exist.
+            controllerTexture = ControllerMappingUtilities.GetControllerTextureScaled(controllerMappingProfile);
+            Assert.IsNotNull(controllerTexture);
+        }
+
+        [Test]
+        public void Test_04_ConfirmProfileControllerTextureUsed()
+        {
+            var controllerMappingProfile = ScriptableObject.CreateInstance<MixedRealityControllerMappingProfile>();
+            controllerMappingProfile.ControllerType = typeof(GenericOpenVRController);
+
+            var dummyTexture = new Texture2D(1, 1, TextureFormat.ARGB32, false);
+            controllerMappingProfile.LightThemeLeftControllerTexture = dummyTexture;
+            controllerMappingProfile.LightThemeLeftControllerTextureScaled = dummyTexture;
+            controllerMappingProfile.LightThemeRightControllerTexture = dummyTexture;
+            controllerMappingProfile.LightThemeRightControllerTextureScaled = dummyTexture;
+            controllerMappingProfile.DarkThemeLeftControllerTexture = dummyTexture;
+            controllerMappingProfile.DarkThemeLeftControllerTextureScaled = dummyTexture;
+            controllerMappingProfile.DarkThemeRightControllerTexture = dummyTexture;
+            controllerMappingProfile.DarkThemeRightControllerTextureScaled = dummyTexture;
+
+            // Right / Any hand textures
+            controllerMappingProfile.Handedness = Definitions.Utilities.Handedness.Right;
+            var controllerTexture = ControllerMappingUtilities.GetControllerTexture(controllerMappingProfile);
+            Assert.AreSame(controllerTexture, dummyTexture);
+            controllerTexture = ControllerMappingUtilities.GetControllerTextureScaled(controllerMappingProfile);
+            Assert.AreSame(controllerTexture, dummyTexture);
+
+            // Left hand textures
+            controllerMappingProfile.Handedness = Definitions.Utilities.Handedness.Left;
+            controllerTexture = ControllerMappingUtilities.GetControllerTexture(controllerMappingProfile);
+            Assert.AreSame(controllerTexture, dummyTexture);
+            controllerTexture = ControllerMappingUtilities.GetControllerTextureScaled(controllerMappingProfile);
+            Assert.AreSame(controllerTexture, dummyTexture);
+
+            dummyTexture.Destroy();
+        }
     }
 }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Adds hidden serialized fields to controller mapping profiles to configure controller textures used in the mapping window and data provider inspector.

![image](https://user-images.githubusercontent.com/9565734/155526757-416be935-ccb0-4d60-b807-3b64b5fbc714.png)

It's implemented in a backwards compatible way so existing controller textures are not broken. For now these fields do not appear in the controller profile inspector and to edit them, one must switch to "DEBUG" inspector mode. This is fine as this is only meant to be used by us internally for now.

### Why is this better than before?

Instead of relying on some magic and top secret paths hard-coded in the toolkit scripts we can now conventienly configure these textures using the respective controleller profile. This allows us to ship these controller textures with the platform package instead of having them all in the core package.

Also this sort of enables support for users to consume these textures for in-game settnigs screens e.g.