### PR TITLE
Added automation pipeline to Core

### DIFF
--- a/.github/workflows/buildupmpackages.yml
+++ b/.github/workflows/buildupmpackages.yml
@@ -46,4 +46,3 @@ jobs:
     with:
       build-target: windows
       unityversion: ${{ needs.Setup-Unity.outputs.unityeditorversion }}
-      dependencies: '{"dependancyname": "dependency repository"}'

--- a/.github/workflows/buildupmpackages.yml
+++ b/.github/workflows/buildupmpackages.yml
@@ -1,0 +1,49 @@
+name: Build and test UPM packages for platforms
+
+on:
+  workflow_call:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+# Example flow
+
+jobs:
+  # Check Unity version requird by the package
+  validate-environment:
+    name: Get Unity Version from UPM package
+    uses: realitycollective/reusableworkflows/.github/workflows/getunityversionfrompackage.yml@main
+    with:
+      build-target: windows
+
+  # Check Unity Hub and Editor Environment
+  Setup-Unity:
+    name: Validate Unity Install
+    needs: validate-environment
+    uses: realitycollective/reusableworkflows/.github/workflows/validateunityinstall.yml@main
+    with:
+      build-target: windows
+      unityversion: ${{ needs.validate-environment.outputs.unityversion }}
+
+  Install-Unity-Editor:
+    if: ${{ needs.Setup-Unity.outputs.unityeditorinstalled }}  == '0'
+    needs: Setup-Unity
+    uses: realitycollective/reusableworkflows/.github/workflows/installunityeditor.yml@main
+    name: Install Unity Editor
+    with:
+      build-target: windows
+      unityversion: ${{ needs.Setup-Unity.outputs.unityeditorversion }}      
+
+  # Run Unity unit tests defined in the package
+  Run-Unit-Tests:
+    name: Run Unity Unit Tests
+    needs: [Setup-Unity, Install-Unity-Editor]
+    uses: realitycollective/reusableworkflows/.github/workflows/rununityunittests.yml@main
+    with:
+      build-target: windows
+      unityversion: ${{ needs.Setup-Unity.outputs.unityeditorversion }}
+      dependencies: '{"dependancyname": "dependency repository"}'

--- a/.github/workflows/buildupmpackages.yml
+++ b/.github/workflows/buildupmpackages.yml
@@ -30,7 +30,7 @@ jobs:
       unityversion: ${{ needs.validate-environment.outputs.unityversion }}
 
   Install-Unity-Editor:
-    if: ${{ needs.Setup-Unity.outputs.unityeditorinstalled }}  == '0'
+    if: ${{ needs.Setup-Unity.outputs.unityeditorinstalled }}  == '1'
     needs: Setup-Unity
     uses: realitycollective/reusableworkflows/.github/workflows/installunityeditor.yml@main
     name: Install Unity Editor

--- a/.github/workflows/pr_assign_creator.yml
+++ b/.github/workflows/pr_assign_creator.yml
@@ -1,0 +1,13 @@
+name: Assign PR to it's author
+
+on: [pull_request]
+
+jobs:
+  automation:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Assign PR to creator
+      uses: thomaseizinger/assign-pr-creator-action@v1.0.0
+      if: github.event_name == 'pull_request' && github.event.action == 'opened'
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.github/
+Tests/
+Tests.meta

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Mixed Reality"
   ],
   "version": "1.0.0-preview.1",
-  "unity": "2020.",
+  "unity": "2020.3",
   "homepage": "https://github.com/realitycollective",
   "bugs": {
     "url": "https://github.com/realitycollective/realitytoolkit.dev/issues"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Mixed Reality"
   ],
   "version": "1.0.0-preview.1",
-  "unity": "2020.2",
+  "unity": "2020.",
   "homepage": "https://github.com/realitycollective",
   "bugs": {
     "url": "https://github.com/realitycollective/realitytoolkit.dev/issues"
@@ -25,7 +25,7 @@
     "url": "https://github.com/realitycollective"
   },
   "dependencies": {
-    "com.unity.modules.vr": "1.0.0",
+    "com.unity.xr.management": "4.2.1",
     "com.unity.modules.unitywebrequest": "1.0.0",
     "com.unity.textmeshpro": "2.1.6",
     "com.unity.editorcoroutines": "1.0.0",


### PR DESCRIPTION
Initial check-in of the automation pipeline, currently setup for simple automating and testing

Pipeline can be updated to include UPM packaging and publishing when ready.

*Note, does not include a Test BUILD at the moment, only runs Unit tests, which will also pick up base coding issues.

##Limitations

I'm checking with Microsoft, but the Actions runners are unable to use the Runners configured for the RealityCollective organisation and I've had to temporarily setup a single runner against the package (possibly because it's a fork)

Once merged, we can look to roll this out to the other packages

P.S.
Also added pipeline action to ensure people who RAISE a PR also set themselves as the assignee for the PR :D 