### PR TITLE
Fix NRE when no gaze provider is active

### DIFF
--- a/Runtime/Interfaces/Providers/Controllers/IMixedRealityControllerDataProvider.cs
+++ b/Runtime/Interfaces/Providers/Controllers/IMixedRealityControllerDataProvider.cs
@@ -15,21 +15,29 @@ namespace XRTK.Interfaces.InputSystem.Providers.Controllers
     public interface IMixedRealityControllerDataProvider : IMixedRealityInputDataProvider
     {
         /// <summary>
-        /// Retrieve all controllers currently registered with this device at runtime (if direct access is required)
+        /// Retrieve all controllers currently registered with this device at runtime (if direct access is required).
         /// </summary>
-        /// <returns></returns>
         IReadOnlyList<IMixedRealityController> ActiveControllers { get; }
 
         /// <summary>
         /// Gets the registered controller mapping profile for the provided <see cref="IMixedRealityController"/>
         /// </summary>
-        /// <param name="controllerType"></param>
-        /// <param name="handedness"></param>
-        /// <returns></returns>
+        /// <param name="controllerType">The type of the <see cref="IMixedRealityController"/> to lookup the profile for.</param>
+        /// <param name="handedness">The <see cref="Handedness"/> the profile should be configured for.</param>
+        /// <returns><see cref="MixedRealityControllerMappingProfile"/> or <c>null</c>.</returns>
         /// <remarks>
         /// Currently you can register more than one controller type and handedness into the
         /// <see cref="BaseMixedRealityControllerDataProviderProfile"/>, but this method will only return the first one found.
         /// </remarks>
         MixedRealityControllerMappingProfile GetControllerMappingProfile(Type controllerType, Handedness handedness);
+
+        /// <summary>
+        /// Gets the <see cref="MixedRealityControllerMappingProfile"/> for <paramref name="controllerType"/>, if it exists.
+        /// </summary>
+        /// <param name="controllerType">The type of the <see cref="IMixedRealityController"/> to lookup the profile for.</param>
+        /// <param name="handedness">The <see cref="Handedness"/> the profile should be configured for.</param>
+        /// <param name="controllerMappingProfile">The found <see cref="MixedRealityControllerMappingProfile"/>.</param>
+        /// <returns><c>true</c>, if found, otherwise <c>false</c>.</returns>
+        bool TryGetControllerMappingProfile(Type controllerType, Handedness handedness, out MixedRealityControllerMappingProfile controllerMappingProfile);
     }
 }

--- a/Runtime/Services/InputSystem/Controllers/BaseControllerDataProvider.cs
+++ b/Runtime/Services/InputSystem/Controllers/BaseControllerDataProvider.cs
@@ -50,31 +50,45 @@ namespace XRTK.Services.InputSystem.Controllers
         /// <inheritdoc />
         public MixedRealityControllerMappingProfile GetControllerMappingProfile(Type controllerType, Handedness handedness)
         {
+            if (TryGetControllerMappingProfile(controllerType, handedness, out var controllerMappingProfile))
+            {
+                return controllerMappingProfile;
+            }
+
+            Debug.LogError($"Failed to find a controller mapping for {controllerType.Name} with with handedness: {handedness}");
+            return null;
+        }
+
+        /// <inheritdoc />
+        public bool TryGetControllerMappingProfile(Type controllerType, Handedness handedness, out MixedRealityControllerMappingProfile controllerMappingProfile)
+        {
             if (controllerType == null)
             {
                 Debug.LogError($"{nameof(controllerType)} is null!");
-                return null;
+                controllerMappingProfile = null;
+                return false;
             }
 
             if (!typeof(IMixedRealityController).IsAssignableFrom(controllerType))
             {
                 Debug.LogError($"{controllerType.Name} does not implement {nameof(IMixedRealityController)}");
-                return null;
+                controllerMappingProfile = null;
+                return false;
             }
 
             // TODO provide a way to choose profiles with additional args instead of returning the first one found.
-
             for (int i = 0; i < controllerMappingProfiles.Length; i++)
             {
                 if (handedness == controllerMappingProfiles[i].Handedness &&
                     controllerMappingProfiles[i].ControllerType?.Type == controllerType)
                 {
-                    return controllerMappingProfiles[i];
+                    controllerMappingProfile = controllerMappingProfiles[i];
+                    return true;
                 }
             }
 
-            Debug.LogError($"Failed to find a controller mapping for {controllerType.Name} with with handedness: {handedness}");
-            return null;
+            controllerMappingProfile = null;
+            return false;
         }
 
         protected void AddController(IMixedRealityController controller)

--- a/Runtime/Services/InputSystem/InputSources/BaseGenericInputSource.cs
+++ b/Runtime/Services/InputSystem/InputSources/BaseGenericInputSource.cs
@@ -25,7 +25,12 @@ namespace XRTK.Services.InputSystem.InputSources
             {
                 SourceId = inputSystem.GenerateNewSourceId();
                 SourceName = name;
-                Pointers = pointers ?? new[] { inputSystem.GazeProvider.GazePointer };
+
+                Pointers = pointers;
+                if (Pointers == null && inputSystem.GazeProvider != null)
+                {
+                    Pointers = new[] { inputSystem.GazeProvider.GazePointer };
+                }
             }
             else
             {


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Fixes an issue where `BaseGenericInputSource` would cause an NRE when no gaze provider is active in the scene. The change makes sure that we check for gaze provider existence before accessing it.

It also adds a new API to `BaseControllerDataProvider` to check for the existence of a mapping profile for a certain controller type, without raising an error if none exists. This is useful for custom data provider profiles, where users may decide to not support a controller at all and removed its mapping profile from the data provider configuration.

## Changes

See above.

## Testing status

* No tests have been added.


### Manual testing status

Tested using Pico platform manually, which is where the issue was initially observed.
