### PR TITLE
Handle NotSupportedException when building type cache

### DIFF
--- a/Editor/Extensions/ScriptableObjectExtensions.cs
+++ b/Editor/Extensions/ScriptableObjectExtensions.cs
@@ -6,7 +6,7 @@ using System.IO;
 using UnityEditor;
 using UnityEngine;
 
-namespace RealityToolkit.Extensions
+namespace RealityToolkit.Editor.Extensions
 {
     /// <summary>
     /// Extensions for <see cref="ScriptableObject"/>s

--- a/Editor/Extensions/ScriptableObjectExtensions.cs.meta
+++ b/Editor/Extensions/ScriptableObjectExtensions.cs.meta
@@ -5,7 +5,7 @@ MonoImporter:
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0
-  icon: {instanceID: 0}
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Editor/Input/Handlers/SpeechInputHandlerInspector.cs
+++ b/Editor/Input/Handlers/SpeechInputHandlerInspector.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using RealityToolkit.Definitions.InputSystem;
-using RealityToolkit.Extensions;
+using RealityToolkit.Editor.Extensions;
 using RealityToolkit.Services.InputSystem.Handlers;
 using UnityEditor;
 using UnityEngine;

--- a/Editor/PropertyDrawers/MixedRealityInputActionDropdown.cs
+++ b/Editor/PropertyDrawers/MixedRealityInputActionDropdown.cs
@@ -4,7 +4,7 @@
 using System;
 using RealityToolkit.Definitions.InputSystem;
 using RealityToolkit.Definitions.Utilities;
-using RealityToolkit.Extensions;
+using RealityToolkit.Editor.Extensions;
 using UnityEditor;
 using UnityEngine;
 

--- a/Tests/TestUtilities.cs
+++ b/Tests/TestUtilities.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using System.Linq;
 using RealityToolkit.Definitions;
 using RealityToolkit.Definitions.LocomotionSystem;
-using RealityToolkit.Extensions;
+using RealityToolkit.Editor.Extensions;
 using RealityToolkit.Interfaces.LocomotionSystem;
 using RealityToolkit.Services;
 using UnityEditor.SceneManagement;


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Added a try-catch block to handle `NotSupportedException` that is being raised by some types when accessing `Type.GUID` in the type cache utility.

## Changes

- Reverted moving scriptable object extensions to runtime assembly because they use editor assembly APIs
- Essentially we are not looking at a full fix here, instead we handle the exception and thus prevent the application from crashing. The exception and error is logged to the console so the dev can take a look at the specific type causing the GUID issue.