### PR TITLE
Fix "AnimatorCursor is already destroyed error" on stopping project

### DIFF
--- a/Runtime/Services/InputSystem/Providers/GazeProvider.cs
+++ b/Runtime/Services/InputSystem/Providers/GazeProvider.cs
@@ -381,7 +381,7 @@ namespace RealityToolkit.Services.InputSystem.Providers
         {
             InputSystem?.Unregister(gameObject);
 
-            if (GazePointer != null && GazeCursor.GameObjectReference.IsNotNull())
+            if (GazePointer != null && !GazeCursor.Equals(null) && GazeCursor.GameObjectReference.IsNotNull())
             {
                 GazeCursor.GameObjectReference.Destroy();
             }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

Fixed the issue where the Gaze Cursor would complain it was already destroyed when stopping the project.

GameObject != null raises an error
!GameObject.Equals(null) does not

Because... Unity

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Updated Null check for the GazeProvider