### PR TITLE
Fix/resolve gaze provider destroy error

### DIFF
--- a/Runtime/Services/InputSystem/Providers/GazeProvider.cs
+++ b/Runtime/Services/InputSystem/Providers/GazeProvider.cs
@@ -29,6 +29,8 @@ namespace RealityToolkit.Services.InputSystem.Providers
 
         private const float MovementThreshold = 0.01f;
 
+        private bool sourceRaised = false;
+
         [SerializeField]
         [Tooltip("Maximum distance at which the gaze can hit a GameObject.")]
         private float maxGazeCollisionDistance = 10.0f;
@@ -374,7 +376,10 @@ namespace RealityToolkit.Services.InputSystem.Providers
         {
             InputSystem?.Unregister(gameObject);
             GazePointer?.BaseCursor?.SetVisibility(false);
-            InputSystem?.RaiseSourceLost(GazeInputSource);
+            if (sourceRaised)
+            {
+                InputSystem?.RaiseSourceLost(GazeInputSource);
+            }
         }
 
         protected void OnDestroy()
@@ -475,6 +480,7 @@ namespace RealityToolkit.Services.InputSystem.Providers
 
             InputSystem.RaiseSourceDetected(GazeInputSource);
             GazePointer.BaseCursor?.SetVisibility(true);
+            sourceRaised = true;
         }
 
         /// <summary>

--- a/Runtime/Services/InputSystem/Providers/GazeProvider.cs
+++ b/Runtime/Services/InputSystem/Providers/GazeProvider.cs
@@ -381,7 +381,7 @@ namespace RealityToolkit.Services.InputSystem.Providers
         {
             InputSystem?.Unregister(gameObject);
 
-            if (GazePointer != null && GazeCursor.GameObjectReference.IsNotNull())
+            if (GazePointer != null && !GazeCursor.Equals(null) && GazeCursor.GameObjectReference.IsNotNull())
             {
                 GazeCursor.GameObjectReference.Destroy();
             }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

Resolves an issue when the GazeProvider is destroyed before it has had a chance to register itself with the Input System, this raises an Assert error in the input system.

The Gaze Provider will now only unregister its input source IF it has actually been registered with the Input System.

## Changes
<!-- Brief list of the targeted features that are being changed. -->

Adds a check to the Gaze Provider, which is set when it is registered.  If not set, the control NO LONGER attempts to unregister itself on destroy.
