### PR TITLE
Fix inspector label for gaze provider mode

### DIFF
--- a/Editor/Profiles/InputSystem/MixedRealityInputSystemProfileInspector.cs
+++ b/Editor/Profiles/InputSystem/MixedRealityInputSystemProfileInspector.cs
@@ -20,7 +20,7 @@ namespace RealityToolkit.Editor.Profiles.InputSystem
     [CustomEditor(typeof(MixedRealityInputSystemProfile))]
     public class MixedRealityInputSystemProfileInspector : ServiceProfileInspector
     {
-        private static readonly GUIContent FocusProviderContent = new GUIContent("Focus Provider");
+        private static readonly GUIContent GazeProviderBehaviourContent = new GUIContent("Gaze Provider Mode");
         private static readonly GUIContent GazeProviderContent = new GUIContent("Gaze Provider");
         private static readonly GUIContent GazeCursorPrefabContent = new GUIContent("Gaze Cursor Prefab");
         private static readonly GUIContent GlobalPointerSettingsContent = new GUIContent("Global Pointer Settings");
@@ -126,7 +126,7 @@ namespace RealityToolkit.Editor.Profiles.InputSystem
             serializedObject.Update();
             EditorGUI.BeginChangeCheck();
 
-            EditorGUILayout.PropertyField(gazeProviderBehaviour, FocusProviderContent);
+            EditorGUILayout.PropertyField(gazeProviderBehaviour, GazeProviderBehaviourContent);
             EditorGUILayout.PropertyField(gazeProviderType, GazeProviderContent);
             EditorGUILayout.PropertyField(gazeCursorPrefab, GazeCursorPrefabContent);
 


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

No idea when this broke. Fixed the label for the gaze provider mode setting in the inspector.