### PR TITLE
use ServiceManager.IsActiveAndInitialized to avoid NREs

### DIFF
--- a/Editor/PackageInstaller.cs
+++ b/Editor/PackageInstaller.cs
@@ -157,7 +157,7 @@ namespace RealityToolkit.Editor
         {
             ServiceProvidersProfile rootProfile;
 
-            if (!(ServiceManager.Instance is null) && ServiceManager.Instance.IsInitialized)
+            if (ServiceManager.IsActiveAndInitialized)
             {
                 rootProfile = ServiceManager.Instance.ActiveProfile;
             }

--- a/Editor/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
+++ b/Editor/Profiles/BaseMixedRealityCameraDataProviderProfileInspector.cs
@@ -124,8 +124,7 @@ namespace RealityToolkit.Editor.Profiles.CameraSystem
 
             serializedObject.ApplyModifiedProperties();
 
-            if (ServiceManager.Instance != null &&
-                ServiceManager.Instance.IsInitialized && EditorGUI.EndChangeCheck())
+            if (ServiceManager.IsActiveAndInitialized && EditorGUI.EndChangeCheck())
             {
                 EditorApplication.delayCall += () => ServiceManager.Instance.ResetProfile(ServiceManager.Instance.ActiveProfile);
             }

--- a/Editor/Profiles/InputSystem/MixedRealityInputSystemProfileInspector.cs
+++ b/Editor/Profiles/InputSystem/MixedRealityInputSystemProfileInspector.cs
@@ -212,8 +212,7 @@ namespace RealityToolkit.Editor.Profiles.InputSystem
             serializedObject.ApplyModifiedProperties();
 
             if (EditorGUI.EndChangeCheck() &&
-                ServiceManager.Instance != null &&
-                ServiceManager.Instance.IsInitialized)
+                ServiceManager.IsActiveAndInitialized)
             {
                 EditorApplication.delayCall += () => ServiceManager.Instance.ResetProfile(ServiceManager.Instance.ActiveProfile);
             }

--- a/Editor/Profiles/MixedRealityCameraSystemProfileInspector.cs
+++ b/Editor/Profiles/MixedRealityCameraSystemProfileInspector.cs
@@ -41,8 +41,7 @@ namespace RealityToolkit.Editor.Profiles.CameraSystem
 
             serializedObject.ApplyModifiedProperties();
 
-            if (ServiceManager.Instance != null &&
-                ServiceManager.Instance.IsInitialized && EditorGUI.EndChangeCheck())
+            if (ServiceManager.IsActiveAndInitialized && EditorGUI.EndChangeCheck())
             {
                 EditorApplication.delayCall += () => ServiceManager.Instance.ResetProfile(ServiceManager.Instance.ActiveProfile);
             }

--- a/Editor/Profiles/MixedRealityPlatformServiceConfigurationProfileInspector.cs
+++ b/Editor/Profiles/MixedRealityPlatformServiceConfigurationProfileInspector.cs
@@ -301,8 +301,7 @@ namespace RealityToolkit.Editor.Profiles
                 }
             }
 
-            if (ServiceManager.Instance != null &&
-                ServiceManager.Instance.IsInitialized && hasChanged)
+            if (ServiceManager.IsActiveAndInitialized && hasChanged)
             {
                 ServiceManager.Instance.ResetProfile(ServiceManager.Instance.ActiveProfile);
             }
@@ -356,8 +355,7 @@ namespace RealityToolkit.Editor.Profiles
 
             serializedObject.ApplyModifiedProperties();
 
-            if (ServiceManager.Instance != null &&
-                ServiceManager.Instance.IsInitialized)
+            if (ServiceManager.IsActiveAndInitialized)
             {
                 EditorApplication.delayCall += () => ServiceManager.Instance.ResetProfile(ServiceManager.Instance.ActiveProfile);
             }

--- a/Editor/Utilities/CanvasEditorExtension.cs
+++ b/Editor/Utilities/CanvasEditorExtension.cs
@@ -33,7 +33,7 @@ namespace RealityToolkit.Editor.Utilities
         {
             get
             {
-                if (!ServiceManager.Instance.IsInitialized ||
+                if (!ServiceManager.IsActiveAndInitialized ||
                     !MixedRealityPreferences.ShowCanvasUtilityPrompt)
                 {
                     return false;


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Fixes some NREs with the service manager, when the service manager is not in the scene and components are checking for it.