### PR TITLE
Add Pointer.IsOverUI API

### DIFF
--- a/Assets~/StandardAssets/Prefabs/UX/Pointers/DefaultControllerPointer.prefab
+++ b/Assets~/StandardAssets/Prefabs/UX/Pointers/DefaultControllerPointer.prefab
@@ -31,7 +31,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -165,6 +164,9 @@ MonoBehaviour:
     axisConstraint: 7
   cursorPrefab: {fileID: 1000012072213228, guid: 79f96834fcc44889b558cc13518979a0, type: 3}
   disableCursorOnStart: 0
+  uiLayerMask:
+    serializedVersion: 2
+    m_Bits: 32
   setCursorVisibilityOnSourceDetected: 0
   raycastOrigin: {fileID: 0}
   activeHoldAction:
@@ -349,7 +351,6 @@ LineRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 0
-  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0

--- a/Editor/UX/Pointers/BaseControllerPointerInspector.cs
+++ b/Editor/UX/Pointers/BaseControllerPointerInspector.cs
@@ -17,6 +17,7 @@ namespace RealityToolkit.Editor.UX.Pointers
 
         private SerializedProperty cursorPrefab;
         private SerializedProperty disableCursorOnStart;
+        private SerializedProperty uiLayerMask;
         private SerializedProperty setCursorVisibilityOnSourceDetected;
         private SerializedProperty raycastOrigin;
         private SerializedProperty defaultPointerExtent;
@@ -37,6 +38,7 @@ namespace RealityToolkit.Editor.UX.Pointers
 
             cursorPrefab = serializedObject.FindProperty(nameof(cursorPrefab));
             disableCursorOnStart = serializedObject.FindProperty(nameof(disableCursorOnStart));
+            uiLayerMask = serializedObject.FindProperty(nameof(uiLayerMask));
             setCursorVisibilityOnSourceDetected = serializedObject.FindProperty(nameof(setCursorVisibilityOnSourceDetected));
             raycastOrigin = serializedObject.FindProperty(nameof(raycastOrigin));
             defaultPointerExtent = serializedObject.FindProperty(nameof(defaultPointerExtent));
@@ -64,6 +66,7 @@ namespace RealityToolkit.Editor.UX.Pointers
                 EditorGUI.indentLevel++;
 
                 EditorGUILayout.PropertyField(disableCursorOnStart);
+                EditorGUILayout.PropertyField(uiLayerMask);
                 EditorGUILayout.PropertyField(setCursorVisibilityOnSourceDetected);
                 EditorGUILayout.PropertyField(enablePointerOnStart);
                 EditorGUILayout.PropertyField(interactionMode);

--- a/Runtime/InputSystem/Interfaces/IMixedRealityPointer.cs
+++ b/Runtime/InputSystem/Interfaces/IMixedRealityPointer.cs
@@ -27,6 +27,11 @@ namespace RealityToolkit.InputSystem.Interfaces
         string PointerName { get; set; }
 
         /// <summary>
+        /// Is the pointer currently over an UI object?
+        /// </summary>
+        bool IsOverUI { get; }
+
+        /// <summary>
         /// The pointer's current controller reference.
         /// </summary>
         IMixedRealityController Controller { get; set; }

--- a/Runtime/InputSystem/Pointers/GenericPointer.cs
+++ b/Runtime/InputSystem/Pointers/GenericPointer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using RealityCollective.Extensions;
 using RealityCollective.ServiceFramework.Services;
 using RealityToolkit.Definitions.Physics;
 using RealityToolkit.InputSystem.Definitions;
@@ -58,6 +59,9 @@ namespace RealityToolkit.InputSystem.Pointers
 
         /// <inheritdoc />
         public string PointerName { get; set; }
+
+        /// <inheritdoc/>
+        public bool IsOverUI { get; } = false;
 
         /// <inheritdoc />
         public virtual IMixedRealityInputSource InputSourceParent

--- a/Runtime/Utilities/UX/Pointers/BaseControllerPointer.cs
+++ b/Runtime/Utilities/UX/Pointers/BaseControllerPointer.cs
@@ -35,6 +35,9 @@ namespace RealityToolkit.Utilities.UX.Pointers
         [SerializeField]
         private bool disableCursorOnStart = false;
 
+        [SerializeField]
+        private LayerMask uiLayerMask = -1;
+
         protected bool DisableCursorOnStart => disableCursorOnStart;
 
         [SerializeField]
@@ -99,6 +102,11 @@ namespace RealityToolkit.Utilities.UX.Pointers
         /// Gets or sets whether this pointer is currently pressed and hold.
         /// </summary>
         protected bool IsHoldPressed { get; set; } = false;
+
+        /// <inheritdoc/>
+        public bool IsOverUI => Result != null &&
+                    Result.CurrentPointerTarget.IsNotNull() &&
+                    uiLayerMask == (uiLayerMask | (1 << Result.CurrentPointerTarget.layer));
 
         /// <summary>
         /// Gets or sets whether there is currently ANY teleportation request by the


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

A very common scenario in production apps is the need to know, whether a pointer is interacting with UI or with other "regular" objects. This PR adds an IsOverUI API to the pointer interface to query that interface on input events.

The API will always return false for GenericPointers.

### Manual testing status

Manually tested.