### PR TITLE
Do not force CanvasUtility down peoples throats

### DIFF
--- a/Runtime/InputSystem/Modules/FocusProvider.cs
+++ b/Runtime/InputSystem/Modules/FocusProvider.cs
@@ -483,11 +483,6 @@ namespace RealityToolkit.InputSystem.Modules
             {
                 RegisterPointers(inputSource);
             }
-
-            if (Application.isEditor && !Application.isPlaying)
-            {
-                UpdateCanvasEventSystems();
-            }
         }
 
         /// <inheritdoc />
@@ -632,24 +627,6 @@ namespace RealityToolkit.InputSystem.Modules
             }
 
             UIRaycastCamera = null;
-        }
-
-        /// <summary>
-        /// Helper for assigning world space canvases event cameras.
-        /// </summary>
-        /// <remarks>Warning! Very expensive. Use sparingly at runtime.</remarks>
-        public void UpdateCanvasEventSystems()
-        {
-            Debug.Assert(UIRaycastCamera != null, "You must assign a UIRaycastCamera on the FocusProvider before updating your canvases.");
-
-            // This will also find disabled GameObjects in the scene.
-            // Warning! this look up is very expensive!
-            var sceneCanvases = Resources.FindObjectsOfTypeAll<Canvas>();
-
-            for (var i = 0; i < sceneCanvases.Length; i++)
-            {
-                sceneCanvases[i].EnsureComponent<CanvasUtility>();
-            }
         }
 
         /// <inheritdoc />

--- a/Runtime/Utilities/CanvasUtility.cs
+++ b/Runtime/Utilities/CanvasUtility.cs
@@ -19,29 +19,20 @@ namespace RealityToolkit.Utilities
         [SerializeField]
         private Canvas canvas;
 
-        /// <summary>
-        /// The canvas this helper script is targeting.
-        /// </summary>
-        public Canvas Canvas
-        {
-            get => canvas;
-            set => canvas = value;
-        }
-
         private void OnEnable()
         {
-            if (Canvas.IsNull())
+            if (canvas.IsNull())
             {
-                Canvas = GetComponent<Canvas>();
+                canvas = GetComponent<Canvas>();
             }
 
-            Debug.Assert(Canvas != null, $"The {nameof(CanvasUtility)} requires a {nameof(Canvas)} component on the game object.");
+            Debug.Assert(canvas.IsNotNull(), $"The {nameof(CanvasUtility)} requires a {nameof(Canvas)} component on the game object.");
 
             if (ServiceManager.IsActiveAndInitialized &&
                 ServiceManager.Instance.TryGetService<IMixedRealityInputSystem>(out var inputSystem) &&
-                Canvas.isRootCanvas && Canvas.renderMode == RenderMode.WorldSpace)
+                canvas.isRootCanvas && canvas.renderMode == RenderMode.WorldSpace)
             {
-                Canvas.worldCamera = inputSystem.FocusProvider.UIRaycastCamera;
+                canvas.worldCamera = inputSystem.FocusProvider.UIRaycastCamera;
             }
         }
     }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

The CanvasUtility keeps messing up prefabs and scenes in my projects all the time, because we are literally showeling it down people's throats on every occassion. I end up with prefabs where multiple CanvasUtilities are on the object and keep unknowingly saving those prefab changes while editing them.

There is only one thing to do with that utility, which is making sure to prompt the user to add it when a World Space canvas is selected. If yes, then we add it. If not, the user is aware it's needed and will add it when needed. We need to stop messing with people's projects without them being aware of it.