### PR TITLE
Fix NRE and input module type used

### DIFF
--- a/Runtime/InputSystem/Modules/FocusProvider.cs
+++ b/Runtime/InputSystem/Modules/FocusProvider.cs
@@ -571,6 +571,15 @@ namespace RealityToolkit.InputSystem.Modules
         private void EnsureUiRaycastCameraSetup()
         {
             const string uiRayCastCameraName = "UIRaycastCamera";
+
+            if (Camera.main.IsNull())
+            {
+                // The main camera is not available yet, so we cannot init the raycat camera
+                // at this time. The get-accessor of the UIRaycastCamera property will ensure
+                // it is set up at a later time when accessed.
+                return;
+            }
+
             GameObject cameraObject;
 
             var existingUiRaycastCameraObject = GameObject.Find(uiRayCastCameraName);
@@ -601,11 +610,7 @@ namespace RealityToolkit.InputSystem.Modules
             uiRaycastCamera.allowDynamicResolution = false;
             uiRaycastCamera.targetDisplay = 0;
             uiRaycastCamera.stereoTargetEye = StereoTargetEyeMask.Both;
-
-            if (Camera.main.IsNotNull())
-            {
-                uiRaycastCamera.cullingMask = Camera.main.cullingMask;
-            }
+            uiRaycastCamera.cullingMask = Camera.main.cullingMask;
 
             if (uiRaycastCameraTargetTexture == null)
             {

--- a/Runtime/RealityToolkit.asmdef
+++ b/Runtime/RealityToolkit.asmdef
@@ -8,7 +8,8 @@
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:b2d046948d6452a4b8485efc9ce0f88c",
         "GUID:13703f41b24bb904cb2305abe6317e3d",
-        "GUID:de07d9dfb71843b46aa2c474f73ca4cc"
+        "GUID:de07d9dfb71843b46aa2c474f73ca4cc",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -17,6 +18,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "1.0.0",
+            "define": "UNITY_INPUT_SYSTEM_ACTIVE"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

- Fixes a NRE when the scene is launched without a camera rig in the scene or any camera for that matter. In this case the raycast camera is created later on when the get-accessor is accessed. No need for additional error logging here, because any attempt to raycast / focus will result in an error log that the UIRaycastCamera does not exist
- Makes sure we do not use `StandaloneInputModule` but `InputSystemUIInputModule` if the input system is in use

### Manual testing status

Tested and verified manually.
