### PR TITLE
Only update gaze provider in play mode

### DIFF
--- a/Runtime/InputSystem/MixedRealityInputSystem.cs
+++ b/Runtime/InputSystem/MixedRealityInputSystem.cs
@@ -246,12 +246,12 @@ namespace RealityToolkit.InputSystem
 
                 speechEventData = new SpeechEventData(eventSystem);
                 dictationEventData = new DictationEventData(eventSystem);
+
+                UpdateGazeProvider();
             }
 
             ServiceManager.Instance.TryGetService(out IMixedRealityFocusProvider focusProvider);
             FocusProvider = focusProvider;
-
-            UpdateGazeProvider();
         }
 
         private void EnsureInputModuleSetup()


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Since the rig is now a prefab the input system should not add any components to it in edit mode.
It creates overrides on the prefab. Instead the input system should simply ensure a gaze provider exist, when entering play mode.
If none exists, create it, otherwise keep it.