### PR TITLE
Focus Provider updated to only create UIRaycast camera when NOT in XR

### DIFF
--- a/Runtime/Input/Modules/FocusProvider.cs
+++ b/Runtime/Input/Modules/FocusProvider.cs
@@ -16,7 +16,6 @@ using RealityToolkit.Utilities.Physics;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.XR.Management;
 using UnityEvents = UnityEngine.EventSystems;
 
 namespace RealityToolkit.Input.Modules
@@ -77,8 +76,6 @@ namespace RealityToolkit.Input.Modules
         public LayerMask[] GlobalPointerRaycastLayerMasks => focusLayerMasks;
 
         private Camera uiRaycastCamera = null;
-
-        private bool xrEnabledAndInitialized => XRGeneralSettings.Instance?.Manager?.activeLoader != null;
 
         /// <inheritdoc />
         public Camera UIRaycastCamera
@@ -584,44 +581,7 @@ namespace RealityToolkit.Input.Modules
                 return;
             }
 
-            if (xrEnabledAndInitialized)
-            {
-                uiRaycastCamera = Camera.main;
-                return;
-            }
-
-            GameObject cameraObject;
-
-            var existingUiRaycastCameraObject = GameObject.Find(uiRayCastCameraName);
-            if (existingUiRaycastCameraObject != null)
-            {
-                cameraObject = existingUiRaycastCameraObject;
-            }
-            else
-            {
-                cameraObject = new GameObject { name = uiRayCastCameraName };
-                cameraObject.transform.SetParent(Camera.main.transform, false);
-                didCreateUIRaycastCamera = true;
-            }
-
-            uiRaycastCamera = cameraObject.EnsureComponent<Camera>();
-            uiRaycastCamera.enabled = false;
-            uiRaycastCamera.clearFlags = CameraClearFlags.Color;
-            uiRaycastCamera.backgroundColor = new Color(0, 0, 0, 1);
-            uiRaycastCamera.orthographic = true;
-            uiRaycastCamera.orthographicSize = 0.5f;
-            uiRaycastCamera.nearClipPlane = 0.0f;
-            uiRaycastCamera.farClipPlane = 1000f;
-            uiRaycastCamera.rect = new Rect(0, 0, 1, 1);
-            uiRaycastCamera.depth = 0;
-            uiRaycastCamera.renderingPath = RenderingPath.UsePlayerSettings;
-            uiRaycastCamera.useOcclusionCulling = false;
-            uiRaycastCamera.allowHDR = false;
-            uiRaycastCamera.allowMSAA = false;
-            uiRaycastCamera.allowDynamicResolution = false;
-            uiRaycastCamera.targetDisplay = 0;
-            uiRaycastCamera.stereoTargetEye = StereoTargetEyeMask.Both;
-            uiRaycastCamera.cullingMask = Camera.main.cullingMask;
+            uiRaycastCamera = Camera.main;
         }
 
         private void CleanUpUiRaycastCamera()

--- a/Runtime/Input/Modules/FocusProvider.cs
+++ b/Runtime/Input/Modules/FocusProvider.cs
@@ -945,10 +945,6 @@ namespace RealityToolkit.Input.Modules
         private void RaycastGraphics(IInteractor pointer, UnityEvents.PointerEventData graphicEventData, LayerMask[] prioritizedLayerMasks, PointerHitResult hitResult)
         {
             Debug.Assert(UIRaycastCamera != null, "Missing UIRaycastCamera!");
-            if (!xrEnabledAndInitialized)
-            {
-                Debug.Assert(UIRaycastCamera.nearClipPlane == 0, "Near plane must be zero for raycast distances to be correct");
-            }
 
             if (pointer.Rays == null || pointer.Rays.Length <= 0)
             {

--- a/Runtime/RealityToolkit.asmdef
+++ b/Runtime/RealityToolkit.asmdef
@@ -8,7 +8,8 @@
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:b2d046948d6452a4b8485efc9ce0f88c",
         "GUID:13703f41b24bb904cb2305abe6317e3d",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:e40ba710768534012815d3193fa296cb"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/RealityToolkit.asmdef
+++ b/Runtime/RealityToolkit.asmdef
@@ -8,8 +8,7 @@
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:b2d046948d6452a4b8485efc9ce0f88c",
         "GUID:13703f41b24bb904cb2305abe6317e3d",
-        "GUID:75469ad4d38634e559750d17036d5f7c",
-        "GUID:e40ba710768534012815d3193fa296cb"
+        "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
In XR Scenarios the UIRaycastCamera is not required as all Canvases use a WorldSPace canvas in the world.

The UI RaycastCamera is only needed in situations that do NOT use XR.

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- UIRayCast camera only enabled if NOT in XR

