### PR TITLE
Apply idle pose if configured on awake

### DIFF
--- a/Runtime/Input/Hands/Visualizers/RiggedHandControllerVisualizer.cs
+++ b/Runtime/Input/Hands/Visualizers/RiggedHandControllerVisualizer.cs
@@ -61,6 +61,12 @@ namespace RealityToolkit.Input.Hands.Visualizers
         {
             base.Awake();
             poseAnimator = new HandPoseAnimator(jointTransformProvider);
+
+            // If an idle pose is configured, instantly apply it.
+            if (idlePose.IsNotNull())
+            {
+                poseAnimator.Transition(idlePose, false);
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Fix / improvement making sure the hand is actually initialized with the configured idle pose when first instantiated.
Previously it would only transition to the idle pose after some input has happened.