### PR TITLE
Fix issue where poke interactors would cause conflicting behaviour with the attach visualizer behaviour

### DIFF
--- a/Runtime/Input/Hands/Visualizers/RiggedHandControllerVisualizer.cs
+++ b/Runtime/Input/Hands/Visualizers/RiggedHandControllerVisualizer.cs
@@ -61,6 +61,12 @@ namespace RealityToolkit.Input.Hands.Visualizers
         {
             base.Awake();
             poseAnimator = new HandPoseAnimator(jointTransformProvider);
+
+            // If an idle pose is configured, instantly apply it.
+            if (idlePose.IsNotNull())
+            {
+                poseAnimator.Transition(idlePose, false);
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Fix issue where poke interactors would cause conflicting behaviour with the attach visualizer behaviour.
Poke interactors do not make sense in combination with this behaviour and will be ignored.