### PR TITLE
Add support for runtime joint initialization

### DIFF
--- a/Runtime/Input/Hands/IHandJointTransformProvider.cs
+++ b/Runtime/Input/Hands/IHandJointTransformProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using UnityEngine;
 
 namespace RealityToolkit.Input.Hands
@@ -8,10 +9,15 @@ namespace RealityToolkit.Input.Hands
     /// <summary>
     /// A <see cref="IHandJointTransformProvider"/> provides a <see cref="Transform"/>
     /// for a <see cref="HandJoint"/>. It can be used for animiation, when you need to modify joint poses
-    /// on a hand rig.
+    /// on a hand rig or whenever you need to access a specific joint on a hand.
     /// </summary>
     public interface IHandJointTransformProvider
     {
+        /// <summary>
+        /// The available joint <see cref="Transform"/>s have changed.
+        /// </summary>
+        event Action JointTransformsChanged;
+
         /// <summary>
         /// Sets the <see cref="Transform"/> for a given <see cref="HandJoint"/>.
         /// </summary>
@@ -23,7 +29,7 @@ namespace RealityToolkit.Input.Hands
         /// Gets the <see cref="Transform"/> representation for <paramref name="joint"/>, if found.
         /// </summary>
         /// <param name="joint">The <see cref="HandJoint"/> to find the <see cref="Transform"/> for.</param>
-        /// <returns><c>true</c>, if found..</returns>
+        /// <returns><c>true</c>, if found.</returns>
         bool TryGetTransform(HandJoint joint, out Transform transform);
     }
 }

--- a/Runtime/Input/Hands/Poses/HandPoseAnimator.cs
+++ b/Runtime/Input/Hands/Poses/HandPoseAnimator.cs
@@ -9,10 +9,26 @@ namespace RealityToolkit.Input.Hands.Poses
     /// </summary>
     public class HandPoseAnimator
     {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="jointTransformProvider">The <see cref="IHandJointTransformProvider"/> used to access joints.</param>
         public HandPoseAnimator(IHandJointTransformProvider jointTransformProvider)
         {
             jointCount = Enum.GetNames(typeof(HandJoint)).Length;
             this.jointTransformProvider = jointTransformProvider;
+            this.jointTransformProvider.JointTransformsChanged += JointTransformProvider_JointTransformsChanged;
+        }
+
+        /// <summary>
+        /// Destructor.
+        /// </summary>
+        ~HandPoseAnimator()
+        {
+            if (jointTransformProvider != null)
+            {
+                jointTransformProvider.JointTransformsChanged -= JointTransformProvider_JointTransformsChanged;
+            }
         }
 
         private readonly int jointCount;
@@ -135,6 +151,16 @@ namespace RealityToolkit.Input.Hands.Poses
                     startFramePoses.Add(handJoint, new Pose(jointTransform.localPosition, jointTransform.localRotation));
                 }
             }
+        }
+
+        private void JointTransformProvider_JointTransformsChanged()
+        {
+            // Whenever the joint providers joints have changed, we must
+            // invalidate the current pose and re-transition to make sure we are working
+            // with latest data.
+            var currentPose = CurrentPose;
+            CurrentPose = null;
+            Transition(currentPose, false);
         }
     }
 }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

When working with the `IHandJointTransformProvider` it is useful to know, when its available joints have changed. This is especially useful when the hand rig is initialized at runtime and at edit time in the editor. E.g. when working with ReadyPlayerMe avatars, an avatars hand rig is only available at runtime after it was downloaded and instantiated.