### PR TITLE
Add Copy API for joint provider

### DIFF
--- a/Runtime/Input/Hands/HandJointTransformProvider.cs
+++ b/Runtime/Input/Hands/HandJointTransformProvider.cs
@@ -49,6 +49,20 @@ namespace RealityToolkit.Input.Hands
         private void InvalidateCache() => Cache.Clear();
 
         /// <inheritdoc/>
+        public void Copy(IHandJointTransformProvider sourceProvider)
+        {
+            var jointCount = Enum.GetNames(typeof(HandJoint)).Length;
+            for (var i = 0; i < jointCount; i++)
+            {
+                var joint = (HandJoint)i;
+                if (sourceProvider.TryGetTransform(joint, out var transform))
+                {
+                    SetTransform(joint, transform);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
         public void SetTransform(HandJoint joint, Transform transform)
         {
             if (transforms == null)

--- a/Runtime/Input/Hands/IHandJointTransformProvider.cs
+++ b/Runtime/Input/Hands/IHandJointTransformProvider.cs
@@ -19,6 +19,12 @@ namespace RealityToolkit.Input.Hands
         event Action JointTransformsChanged;
 
         /// <summary>
+        /// Copies all joint <see cref="Transform"/> information from the <paramref name="sourceProvider"/>.
+        /// </summary>
+        /// <param name="sourceProvider">The <see cref="IHandJointTransformProvider"/> to copy from.</param>
+        void Copy(IHandJointTransformProvider sourceProvider);
+
+        /// <summary>
         /// Sets the <see cref="Transform"/> for a given <see cref="HandJoint"/>.
         /// </summary>
         /// <param name="joint">The <see cref="HandJoint"/> to set the <see cref="Transform"/> for.</param>


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Another useful addition derived from an active project where I have to configure avatars at runtime.
This new API allows copying hand joint information from one provider to the other, which is useful
when linking hand joints across game objects.