### PR TITLE
Lock visualizer behaviour improvement

### DIFF
--- a/Editor/Inspectors/GrabHandPoseBehaviourInspector.cs
+++ b/Editor/Inspectors/GrabHandPoseBehaviourInspector.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityToolkit.Input.InteractionBehaviours;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace RealityToolkit.Editor.Inspectors
+{
+    [CustomEditor(typeof(GrabHandPoseBehaviour), true)]
+    public class GrabHandPoseBehaviourInspector : BaseInteractionBehaviourInspector
+    {
+        private const string grabPose = "grabPose";
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public override VisualElement CreateInspectorGUI()
+        {
+            var inspector = base.CreateInspectorGUI();
+
+            inspector.Add(new PropertyField(serializedObject.FindProperty(grabPose)));
+
+            return inspector;
+        }
+    }
+}

--- a/Editor/Inspectors/GrabHandPoseBehaviourInspector.cs.meta
+++ b/Editor/Inspectors/GrabHandPoseBehaviourInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 026d5538e11332f41bdb589a70ac20e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspectors/LockControllerVisualizerBehaviourInspector.cs
+++ b/Editor/Inspectors/LockControllerVisualizerBehaviourInspector.cs
@@ -14,13 +14,11 @@ namespace RealityToolkit.Editor.Inspectors
     {
         private VisualElement inspector;
         private PropertyField smoothSyncPose;
-        private PropertyField syncPositionSpeed;
-        private PropertyField syncRotationSpeed;
+        private PropertyField syncDuration;
 
-        private const string grabOffsetPoseBindingPath = "localOffsetPose";
-        private const string smoothSyncPoseBindingPath = "smoothSyncPose";
-        private const string syncPositionSpeedBindingPath = "syncPositionSpeed";
-        private const string syncRotationSpeedBindingPath = "syncRotationSpeed";
+        private const string localOffsetPoseBindingPath = "localOffsetPose";
+        private const string smoothSyncPoseBindingPath = nameof(smoothSyncPose);
+        private const string syncPositionSpeedBindingPath = nameof(syncDuration);
 
         /// <summary>
         /// <inheritdoc/>
@@ -29,17 +27,14 @@ namespace RealityToolkit.Editor.Inspectors
         {
             inspector = base.CreateInspectorGUI();
 
-            inspector.Add(new PropertyField(serializedObject.FindProperty(grabOffsetPoseBindingPath)));
+            inspector.Add(new PropertyField(serializedObject.FindProperty(localOffsetPoseBindingPath)));
 
             smoothSyncPose = new PropertyField(serializedObject.FindProperty(smoothSyncPoseBindingPath));
             smoothSyncPose.RegisterCallback<ChangeEvent<bool>>(SmoothSyncPose_ValueChanged);
             inspector.Add(smoothSyncPose);
 
-            syncPositionSpeed = new PropertyField(serializedObject.FindProperty(syncPositionSpeedBindingPath));
-            syncPositionSpeed.style.paddingLeft = UIElementsUtilities.DefaultInset;
-
-            syncRotationSpeed = new PropertyField(serializedObject.FindProperty(syncRotationSpeedBindingPath));
-            syncRotationSpeed.style.paddingLeft = UIElementsUtilities.DefaultInset;
+            syncDuration = new PropertyField(serializedObject.FindProperty(syncPositionSpeedBindingPath));
+            syncDuration.style.paddingLeft = UIElementsUtilities.DefaultInset;
 
             UpdateSmoothSyncPoseFields(serializedObject.FindProperty(smoothSyncPoseBindingPath).boolValue);
 
@@ -63,21 +58,14 @@ namespace RealityToolkit.Editor.Inspectors
         {
             if (showFields)
             {
-                inspector.Add(syncPositionSpeed);
-                syncPositionSpeed.PlaceInFront(smoothSyncPose);
-                inspector.Add(syncRotationSpeed);
-                syncRotationSpeed.PlaceInFront(syncPositionSpeed);
+                inspector.Add(syncDuration);
+                syncDuration.PlaceInFront(smoothSyncPose);
                 return;
             }
 
-            if (inspector.Contains(syncPositionSpeed))
+            if (inspector.Contains(syncDuration))
             {
-                inspector.Remove(syncPositionSpeed);
-            }
-
-            if (inspector.Contains(syncRotationSpeed))
-            {
-                inspector.Remove(syncRotationSpeed);
+                inspector.Remove(syncDuration);
             }
         }
     }

--- a/Runtime/Input/Hands/Poses/HandPoseAnimator.cs
+++ b/Runtime/Input/Hands/Poses/HandPoseAnimator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -36,7 +36,30 @@ namespace RealityToolkit.Input.Hands.Poses
         private readonly Dictionary<HandJoint, Pose> startFramePoses = new Dictionary<HandJoint, Pose>();
         private bool animating;
         private float animationStartTime;
-        private const float animationDuration = .2f;
+
+        /// <summary>
+        /// Default duration for <see cref="AnimationDuration"/>.
+        /// </summary>
+        public const float DefaultAnimationDuration = .2f;
+
+        private float animationDuration = DefaultAnimationDuration;
+        /// <summary>
+        /// The duration in seconds to transition from one pose to another.
+        /// </summary>
+        public float AnimationDuration
+        {
+            get => animationDuration;
+            set
+            {
+                if (value <= 0f)
+                {
+                    value = DefaultAnimationDuration;
+                    Debug.LogWarning($"{nameof(HandPoseAnimator)} animation duration cannot be below or equal 0. Reverting to default animation duration of {DefaultAnimationDuration} seconds.");
+                }
+
+                animationDuration = value;
+            }
+        }
 
         /// <summary>
         /// The current <see cref="HandPose"/> visualized.
@@ -54,7 +77,7 @@ namespace RealityToolkit.Input.Hands.Poses
                 return;
             }
 
-            var t = (Time.time - animationStartTime) / animationDuration;
+            var t = (Time.time - animationStartTime) / AnimationDuration;
             Slerp(t);
 
             if (t >= 1f)

--- a/Runtime/Input/InteractionBehaviours/BaseInteractionBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/BaseInteractionBehaviour.cs
@@ -16,7 +16,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     [RequireComponent(typeof(Interactable))]
     public abstract class BaseInteractionBehaviour : MonoBehaviour, IInteractionBehaviour
     {
-        [SerializeField, Range(0, 100), Tooltip("Behaviours with a higher sorting order will always be executed after the ones with a lower sorting order.")]
+        [SerializeField, Range(-100, 100), Tooltip("Behaviours with a higher sorting order will always be executed after the ones with a lower sorting order.")]
         private short sortingOrder = 0;
 
         [SerializeField, Tooltip("The handedness of the interactor to perform the Behaviour for." +

--- a/Runtime/Input/InteractionBehaviours/InteractorTrackingMode.cs
+++ b/Runtime/Input/InteractionBehaviours/InteractorTrackingMode.cs
@@ -4,16 +4,16 @@
 namespace RealityToolkit.Input.InteractionBehaviours
 {
     /// <summary>
-    /// Supported interactor tracking modes.
+    /// Supported <see cref="Interactors.IInteractor"/> tracking modes.
     /// </summary>
     public enum InteractorTrackingMode
     {
         /// <summary>
-        /// We are tracking the interactors position to determine lever movement.
+        /// We are tracking the interactors position upon interaction.
         /// </summary>
         Position = 0,
         /// <summary>
-        /// We are tracking the interactors rotation to determine lever movement.
+        /// We are tracking the interactors rotation upon interaction.
         /// </summary>
         Rotation
     }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

- Improves the lock visualizer interaction behaviour in a way that the visualizer will smoothly transition position and rotation within a configurable time. Previously this was also possible but position and rotation would arrive at their target value independently, which looks weird and unnatural
- Allow negative sorting value for interaction behaviour sorting order. New range is -100 to 100 with a default of 0
- Fixed some docs on enum type `InteractorTrackingMode`
- Allow overriding hand pose transition animation duration on `HandPoseAnimator`. This can be used to adjust animation duration depending on how we are interacting with an object