### PR TITLE
Implement smooth visualizer unlock

### DIFF
--- a/Runtime/Input/Controllers/BaseControllerVisualizer.cs
+++ b/Runtime/Input/Controllers/BaseControllerVisualizer.cs
@@ -22,6 +22,9 @@ namespace RealityToolkit.Input.Controllers
         public GameObject GameObject => gameObject;
 
         /// <inheritdoc />
+        public Pose SourcePose { get; private set; }
+
+        /// <inheritdoc />
         public bool OverrideSourcePose { get; set; }
 
         /// <inheritdoc />
@@ -41,6 +44,8 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Pose> eventData)
         {
+            SourcePose = eventData.SourceData;
+
             if (OverrideSourcePose)
             {
                 return;
@@ -52,6 +57,8 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Quaternion> eventData)
         {
+            SourcePose = new Pose(SourcePose.position, eventData.SourceData);
+
             if (OverrideSourcePose)
             {
                 return;
@@ -63,6 +70,8 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Vector2> eventData)
         {
+            SourcePose = new Pose(eventData.SourceData, SourcePose.rotation);
+
             if (OverrideSourcePose)
             {
                 return;
@@ -74,6 +83,8 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Vector3> eventData)
         {
+            SourcePose = new Pose(eventData.SourceData, SourcePose.rotation);
+
             if (OverrideSourcePose)
             {
                 return;

--- a/Runtime/Input/Controllers/IControllerVisualizer.cs
+++ b/Runtime/Input/Controllers/IControllerVisualizer.cs
@@ -19,6 +19,12 @@ namespace RealityToolkit.Input.Controllers
         GameObject GameObject { get; }
 
         /// <summary>
+        /// This is the actual pose of this controller, regardless of <see cref="OverrideSourcePose"/>
+        /// and the <see cref="IControllerPoseSynchronizer.PoseDriver"/> pose.
+        /// </summary>
+        Pose SourcePose { get; }
+
+        /// <summary>
         /// If set, the <see cref="IControllerPoseSynchronizer.PoseDriver"/>'s pose in the scene
         /// is override and the actual <see cref="IController.InputSource"/> pose is ignored.
         /// </summary>

--- a/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
@@ -50,7 +50,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
 
             foreach (var visualizer in visualizers)
             {
-                var shouldLock = HasFinishedSmoothTransition(visualizer, lockPose);
+                var shouldLock = HasFinishedSmoothTransition(visualizer);
 
                 if (!shouldLock)
                 {
@@ -130,7 +130,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
 
         private Pose GetLockPose() => new Pose(transform.TransformPoint(localOffsetPose.position), transform.rotation * Quaternion.Euler(localOffsetPose.rotation.eulerAngles));
 
-        private bool HasFinishedSmoothTransition(IControllerVisualizer visualizer, Pose snapPose)
+        private bool HasFinishedSmoothTransition(IControllerVisualizer visualizer)
         {
             if (lockedVisualizers[visualizer])
             {

--- a/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
@@ -33,6 +33,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
         private float syncDuration = 1f;
 
         private readonly Dictionary<IControllerVisualizer, bool> lockedVisualizers = new();
+        private readonly Dictionary<IControllerVisualizer, bool> pendingUnlockVisualizers = new();
         private readonly Dictionary<IControllerVisualizer, Pose> smoothingStartPose = new();
         private readonly Dictionary<IControllerVisualizer, float> smoothingStartTime = new();
         private readonly Dictionary<IControllerVisualizer, float> smoothingProgress = new();
@@ -50,15 +51,32 @@ namespace RealityToolkit.Input.InteractionBehaviours
 
             foreach (var visualizer in visualizers)
             {
-                var shouldLock = HasFinishedSmoothTransition(visualizer);
-
-                if (!shouldLock)
+                if (pendingUnlockVisualizers.TryGetValue(visualizer, out _))
                 {
-                    lockPose.position = Vector3.Slerp(smoothingStartPose[visualizer].position, lockPose.position, smoothingProgress[visualizer]);
-                    lockPose.rotation = Quaternion.Slerp(smoothingStartPose[visualizer].rotation, lockPose.rotation, smoothingProgress[visualizer]);
-                }
+                    var finishedUnlock = HasFinishedSmoothTransition(pendingUnlockVisualizers, visualizer);
+                    if (finishedUnlock)
+                    {
+                        CleanUpVisualizer(visualizer);
+                        continue;
+                    }
 
-                visualizer.PoseDriver.SetPositionAndRotation(lockPose.position, lockPose.rotation);
+                    var unlockPose = visualizer.SourcePose;
+                    unlockPose.position = Vector3.Slerp(smoothingStartPose[visualizer].position, unlockPose.position, smoothingProgress[visualizer]);
+                    unlockPose.rotation = Quaternion.Slerp(smoothingStartPose[visualizer].rotation, unlockPose.rotation, smoothingProgress[visualizer]);
+                    visualizer.PoseDriver.SetPositionAndRotation(unlockPose.position, unlockPose.rotation);
+                }
+                else
+                {
+                    var shouldLock = HasFinishedSmoothTransition(lockedVisualizers, visualizer);
+
+                    if (!shouldLock)
+                    {
+                        lockPose.position = Vector3.Slerp(smoothingStartPose[visualizer].position, lockPose.position, smoothingProgress[visualizer]);
+                        lockPose.rotation = Quaternion.Slerp(smoothingStartPose[visualizer].rotation, lockPose.rotation, smoothingProgress[visualizer]);
+                    }
+
+                    visualizer.PoseDriver.SetPositionAndRotation(lockPose.position, lockPose.rotation);
+                }
             }
         }
 
@@ -121,18 +139,33 @@ namespace RealityToolkit.Input.InteractionBehaviours
 
         private void UnlockVisualizer(IControllerVisualizer visualizer)
         {
+            if (!smoothSyncPose)
+            {
+                CleanUpVisualizer(visualizer);
+                return;
+            }
+
+            pendingUnlockVisualizers.EnsureDictionaryItem(visualizer, false, true);
+            smoothingStartPose.EnsureDictionaryItem(visualizer, GetLockPose(), true);
+            smoothingStartTime.EnsureDictionaryItem(visualizer, Time.time, true);
+            smoothingProgress.EnsureDictionaryItem(visualizer, 0f, true);
+        }
+
+        private void CleanUpVisualizer(IControllerVisualizer visualizer)
+        {
             lockedVisualizers.SafeRemoveDictionaryItem(visualizer);
             smoothingStartPose.SafeRemoveDictionaryItem(visualizer);
             smoothingStartTime.SafeRemoveDictionaryItem(visualizer);
             smoothingProgress.SafeRemoveDictionaryItem(visualizer);
+            pendingUnlockVisualizers.SafeRemoveDictionaryItem(visualizer);
             visualizer.OverrideSourcePose = false;
         }
 
         private Pose GetLockPose() => new Pose(transform.TransformPoint(localOffsetPose.position), transform.rotation * Quaternion.Euler(localOffsetPose.rotation.eulerAngles));
 
-        private bool HasFinishedSmoothTransition(IControllerVisualizer visualizer)
+        private bool HasFinishedSmoothTransition(Dictionary<IControllerVisualizer, bool> smoothingStateDictionary, IControllerVisualizer visualizer)
         {
-            if (lockedVisualizers[visualizer])
+            if (smoothingStateDictionary[visualizer])
             {
                 return true;
             }
@@ -145,7 +178,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
                 return false;
             }
 
-            lockedVisualizers[visualizer] = true;
+            smoothingStateDictionary[visualizer] = true;
             return true;
         }
     }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

When unlocking a controller visualizer from an interactable pose, it can now perform a smooth transition back to the actual input source pose instead of teleporting. This makes for a much better experience.