### PR TITLE
Fix jaggy hand pose transition when an interactable overrides the hand pose to use

### DIFF
--- a/Assets~/Profiles/Input/InteractorsProfile.asset
+++ b/Assets~/Profiles/Input/InteractorsProfile.asset
@@ -12,7 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f1708952b3739a47908a0fb9a103a7e, type: 3}
   m_Name: InteractorsProfile
   m_EditorClassIdentifier: 
-  pointingExtent: 10
   pointerRaycastLayerMasks:
   - serializedVersion: 2
     m_Bits: 4294967291

--- a/Runtime/Input/Controllers/BaseControllerVisualizer.cs
+++ b/Runtime/Input/Controllers/BaseControllerVisualizer.cs
@@ -44,7 +44,10 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Pose> eventData)
         {
-            SourcePose = eventData.SourceData;
+            if (eventData.SourceId == Controller?.InputSource.SourceId)
+            {
+                SourcePose = eventData.SourceData;
+            }
 
             if (OverrideSourcePose)
             {
@@ -57,7 +60,10 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Quaternion> eventData)
         {
-            SourcePose = new Pose(SourcePose.position, eventData.SourceData);
+            if (eventData.SourceId == Controller?.InputSource.SourceId)
+            {
+                SourcePose = new Pose(SourcePose.position, eventData.SourceData);
+            }
 
             if (OverrideSourcePose)
             {
@@ -70,7 +76,10 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Vector2> eventData)
         {
-            SourcePose = new Pose(eventData.SourceData, SourcePose.rotation);
+            if (eventData.SourceId == Controller?.InputSource.SourceId)
+            {
+                SourcePose = new Pose(eventData.SourceData, SourcePose.rotation);
+            }
 
             if (OverrideSourcePose)
             {
@@ -83,7 +92,10 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Vector3> eventData)
         {
-            SourcePose = new Pose(eventData.SourceData, SourcePose.rotation);
+            if (eventData.SourceId == Controller?.InputSource.SourceId)
+            {
+                SourcePose = new Pose(eventData.SourceData, SourcePose.rotation);
+            }
 
             if (OverrideSourcePose)
             {

--- a/Runtime/Input/Hands/Poses/IProvideHandPose.cs
+++ b/Runtime/Input/Hands/Poses/IProvideHandPose.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace RealityToolkit.Input.Hands.Poses
+{
+    /// <summary>
+    /// Identifies and implementation that provides <see cref="HandPose"/>s to <see cref="Visualizers.BaseHandControllerVisualizer"/>s.
+    /// </summary>
+    public interface IProvideHandPose
+    {
+        /// <summary>
+        /// Optional focus <see cref="HandPose"/> override.
+        /// </summary>
+        HandPose FocusPose { get; }
+
+        /// <summary>
+        /// Optional select <see cref="HandPose"/> override.
+        /// </summary>
+        HandPose SelectPose { get; }
+
+        /// <summary>
+        /// Optional grab <see cref="HandPose"/> override.
+        /// </summary>
+        HandPose GrabPose { get; }
+    }
+}

--- a/Runtime/Input/Hands/Poses/IProvideHandPose.cs.meta
+++ b/Runtime/Input/Hands/Poses/IProvideHandPose.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c7cf14754359b34b84e6fc71b2081a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Hands/Visualizers/BaseHandControllerVisualizer.cs
+++ b/Runtime/Input/Hands/Visualizers/BaseHandControllerVisualizer.cs
@@ -1,7 +1,10 @@
-// Copyright (c) Reality Collective. All rights reserved.
+﻿// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using RealityCollective.Utilities.Extensions;
+using RealityToolkit.EventDatum.Input;
 using RealityToolkit.Input.Controllers;
+using RealityToolkit.Input.Hands.Poses;
 using System;
 using UnityEngine;
 
@@ -24,6 +27,47 @@ namespace RealityToolkit.Input.Hands.Visualizers
                 Debug.LogError($"{GetType().Name} requires an {nameof(IHandJointTransformProvider)} on the {nameof(UnityEngine.GameObject)}.", this);
                 return;
             }
+        }
+
+        /// <summary>
+        /// Checks whether any of the <see cref="Interactors.IInteractor"/>s on this <see cref="BaseHandControllerVisualizer"/> is targeting
+        /// an object that has a <see cref="IProvideHandPose"/> implementation attached to it.
+        /// </summary>
+        /// <param name="eventData">The input event data received.</param>
+        /// <param name="checkFocus">Check whether there is a <see cref="IProvideHandPose"/> that provides a focus pose.</param>
+        /// <param name="checkSelect">Check whether there is a <see cref="IProvideHandPose"/> that provides a select pose.</param>
+        /// <param name="checkGrab">Check whether there is a <see cref="IProvideHandPose"/> that provides a grab pose.</param>
+        /// <returns></returns>
+        protected bool IsTargetingHandPoseProvider(InputEventData eventData, bool checkFocus, bool checkSelect, bool checkGrab)
+        {
+            for (var i = 0; i < eventData.InputSource.Pointers.Length; i++)
+            {
+                var interactor = eventData.InputSource.Pointers[i];
+                if (interactor.Result.CurrentTarget.IsNotNull())
+                {
+                    var poseProviders = interactor.Result.CurrentTarget.GetComponents<IProvideHandPose>();
+                    for (var j = 0; j < poseProviders.Length; j++)
+                    {
+                        var poseProvider = poseProviders[j];
+                        if (checkFocus && poseProvider.FocusPose.IsNotNull())
+                        {
+                            return true;
+                        }
+
+                        if (checkSelect && poseProvider.SelectPose.IsNotNull())
+                        {
+                            return true;
+                        }
+
+                        if (checkGrab && poseProvider.GrabPose.IsNotNull())
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Runtime/Input/Hands/Visualizers/RiggedHandControllerVisualizer.cs
+++ b/Runtime/Input/Hands/Visualizers/RiggedHandControllerVisualizer.cs
@@ -86,12 +86,14 @@ namespace RealityToolkit.Input.Hands.Visualizers
             }
 
             if (eventData.InputSource == Controller.InputSource &&
-                eventData.InputAction == selectInputAction)
+                eventData.InputAction == selectInputAction &&
+                !IsTargetingHandPoseProvider(eventData, false, true, false))
             {
                 poseAnimator.Transition(selectHandPose);
             }
             else if (eventData.InputSource == Controller.InputSource &&
-                eventData.InputAction == gripInputAction)
+                eventData.InputAction == gripInputAction &&
+                !IsTargetingHandPoseProvider(eventData, false, false, true))
             {
                 poseAnimator.Transition(gripHandPose);
             }
@@ -106,12 +108,14 @@ namespace RealityToolkit.Input.Hands.Visualizers
             }
 
             if (eventData.InputSource == Controller.InputSource &&
-                eventData.InputAction == selectInputAction)
+                eventData.InputAction == selectInputAction &&
+                !IsTargetingHandPoseProvider(eventData, false, true, false))
             {
                 poseAnimator.Transition(idlePose);
             }
             else if (eventData.InputSource == Controller.InputSource &&
-                eventData.InputAction == gripInputAction)
+                eventData.InputAction == gripInputAction &&
+                !IsTargetingHandPoseProvider(eventData, false, false, true))
             {
                 poseAnimator.Transition(idlePose);
             }
@@ -130,12 +134,14 @@ namespace RealityToolkit.Input.Hands.Visualizers
             }
 
             if (eventData.InputSource == Controller.InputSource &&
-                eventData.InputAction == selectInputAction)
+                eventData.InputAction == selectInputAction &&
+                !IsTargetingHandPoseProvider(eventData, false, true, false))
             {
                 OnSingleAxisInputChanged(eventData.InputData, selectHandPose);
             }
             else if (eventData.InputSource == Controller.InputSource &&
-                eventData.InputAction == gripInputAction)
+                eventData.InputAction == gripInputAction &&
+                !IsTargetingHandPoseProvider(eventData, false, false, true))
             {
                 OnSingleAxisInputChanged(eventData.InputData, gripHandPose);
             }

--- a/Runtime/Input/Interactables/Interactable.cs
+++ b/Runtime/Input/Interactables/Interactable.cs
@@ -49,7 +49,6 @@ namespace RealityToolkit.Input.Interactables
         [Tooltip("The action that will grab this interactable, if focused by an interactor.")]
         protected InputAction grabAction = InputAction.None;
 
-        [Space]
         [SerializeField, Tooltip("The focus mode for this interactable.")]
         private InteractableFocusMode focusMode = InteractableFocusMode.Single;
 

--- a/Runtime/Input/InteractionBehaviours/FocusHandPoseBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/FocusHandPoseBehaviour.cs
@@ -14,13 +14,22 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// into the assigned <see cref="focusPose"/>, when the <see cref="Interactables.IInteractable"/> is focused.
     [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/focus-hand-pose-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(FocusHandPoseBehaviour))]
-    public class FocusHandPoseBehaviour : BaseInteractionBehaviour
+    public class FocusHandPoseBehaviour : BaseInteractionBehaviour, IProvideHandPose
     {
         [SerializeField, Tooltip("Hand pose applied when focusing the interactable.")]
         private HandPose focusPose = null;
 
         /// <inheritdoc/>
-        protected override void OnFirstFocusEntered(InteractionEventArgs eventArgs)
+        public HandPose FocusPose => focusPose;
+
+        /// <inheritdoc/>
+        public HandPose SelectPose { get; } = null;
+
+        /// <inheritdoc/>
+        public HandPose GrabPose { get; } = null;
+
+        /// <inheritdoc/>
+        protected override void OnFocusEntered(InteractionEventArgs eventArgs)
         {
             if (Interactable.IsSelected || Interactable.IsGrabbed)
             {
@@ -35,7 +44,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
         }
 
         /// <inheritdoc/>
-        protected override void OnLastFocusExited(InteractionExitEventArgs eventArgs)
+        protected override void OnFocusExited(InteractionExitEventArgs eventArgs)
         {
             if (Interactable.IsSelected || Interactable.IsGrabbed)
             {

--- a/Runtime/Input/InteractionBehaviours/GrabHandPoseBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/GrabHandPoseBehaviour.cs
@@ -14,10 +14,19 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// into the assigned <see cref="grabPose"/>, when the <see cref="Interactables.IInteractable"/> is grabbed.
     [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/grab-hand-pose-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(GrabHandPoseBehaviour))]
-    public class GrabHandPoseBehaviour : BaseInteractionBehaviour
+    public class GrabHandPoseBehaviour : BaseInteractionBehaviour, IProvideHandPose
     {
         [SerializeField, Tooltip("Hand pose applied when grabbing the interactable.")]
         private HandPose grabPose = null;
+
+        /// <inheritdoc/>
+        public HandPose FocusPose { get; } = null;
+
+        /// <inheritdoc/>
+        public HandPose SelectPose { get; } = null;
+
+        /// <inheritdoc/>
+        public HandPose GrabPose => grabPose;
 
         /// <inheritdoc/>
         protected override void OnGrabEntered(InteractionEventArgs eventArgs)

--- a/Runtime/Input/InteractionBehaviours/SelectHandPoseBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/SelectHandPoseBehaviour.cs
@@ -1,0 +1,48 @@
+﻿using RealityToolkit.Input.Events;
+using RealityToolkit.Input.Hands.Poses;
+using RealityToolkit.Input.Hands.Visualizers;
+using RealityToolkit.Input.Interactors;
+using UnityEngine;
+
+namespace RealityToolkit.Input.InteractionBehaviours
+{
+    /// <summary>
+    /// The <see cref="SelectHandPoseBehaviour"/> will animate the <see cref="RiggedHandControllerVisualizer"/>
+    /// into the assigned <see cref="selectPose"/>, when the <see cref="Interactables.IInteractable"/> is selected.
+    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/select-hand-pose-behaviour")]
+    [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(SelectHandPoseBehaviour))]
+    public class SelectHandPoseBehaviour : BaseInteractionBehaviour, IProvideHandPose
+    {
+        [SerializeField, Tooltip("Select pose applied when selecting the interactable.")]
+        private HandPose selectPose = null;
+
+        /// <inheritdoc/>
+        public HandPose FocusPose { get; } = null;
+
+        /// <inheritdoc/>
+        public HandPose SelectPose => selectPose;
+
+        /// <inheritdoc/>
+        public HandPose GrabPose { get; } = null;
+
+        /// <inheritdoc/>
+        protected override void OnSelectEntered(InteractionEventArgs eventArgs)
+        {
+            if (eventArgs.Interactor is IDirectInteractor directInteractor &&
+                directInteractor.Controller.Visualizer is RiggedHandControllerVisualizer riggedHandControllerVisualizer)
+            {
+                riggedHandControllerVisualizer.OverridePose = selectPose;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnSelectExited(InteractionExitEventArgs eventArgs)
+        {
+            if (eventArgs.Interactor is IDirectInteractor directInteractor &&
+                directInteractor.Controller.Visualizer is RiggedHandControllerVisualizer riggedHandControllerVisualizer)
+            {
+                riggedHandControllerVisualizer.OverridePose = null;
+            }
+        }
+    }
+}

--- a/Runtime/Input/InteractionBehaviours/SelectHandPoseBehaviour.cs.meta
+++ b/Runtime/Input/InteractionBehaviours/SelectHandPoseBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9be535c51f0be414590e501cd5585c8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 08c0fd91bdca45afa09ec64323cf3848, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

This PR concludes my series for enhancing interactions and making them more immersive by fixing the issue, where the the hand controller visualizer would assume a e.g. grab pose even before it actually reaches the target to grab. The default hand pose and the override hand pose of the interactable would also fight each other for a couple  of frames, which looked weird.

### Final result of enhancements

https://github.com/user-attachments/assets/ae9d99fb-c6c0-4535-a42f-8b7f023181b7

