### PR TITLE
Introduce Interactable reset API and behaviour using it

### DIFF
--- a/Editor/Inspectors/AutoResetBehaviourInspector.cs
+++ b/Editor/Inspectors/AutoResetBehaviourInspector.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityToolkit.Input.InteractionBehaviours;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace RealityToolkit.Editor.Inspectors
+{
+    [CustomEditor(typeof(AutoResetBehaviour), true)]
+    public class AutoResetBehaviourInspector : BaseInteractionBehaviourInspector
+    {
+        private const string resetDelay = "resetDelay";
+        private const string resetPose = "resetPose";
+
+        /// <summary>
+        /// The <see cref="AutoResetBehaviour"/> does not care what the interactor handedness
+        /// is and thus we can hide this setting from the user.
+        /// </summary>
+        protected override bool ShowHandedness => false;
+
+        public override VisualElement CreateInspectorGUI()
+        {
+            var inspector = base.CreateInspectorGUI();
+
+            inspector.Add(new PropertyField(serializedObject.FindProperty(resetDelay)));
+            inspector.Add(new PropertyField(serializedObject.FindProperty(resetPose)));
+
+            return inspector;
+        }
+    }
+}

--- a/Editor/Inspectors/AutoResetBehaviourInspector.cs.meta
+++ b/Editor/Inspectors/AutoResetBehaviourInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a67d25fcdc22824194667fee02f5ac6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspectors/BaseInteractionBehaviourInspector.cs
+++ b/Editor/Inspectors/BaseInteractionBehaviourInspector.cs
@@ -12,6 +12,13 @@ namespace RealityToolkit.Editor.Inspectors
         private const string targetHandednessBindingPath = "targetHandedness";
 
         /// <summary>
+        /// Used internally by some <see cref="BaseInteractionBehaviourInspector"/>
+        /// implementations to hide the handedness field from the inspector, likely because that
+        /// behaviour works without that setting impacting it.
+        /// </summary>
+        protected virtual bool ShowHandedness => true;
+
+        /// <summary>
         /// <inheritdoc/>
         /// </summary>
         public override VisualElement CreateInspectorGUI()
@@ -19,7 +26,11 @@ namespace RealityToolkit.Editor.Inspectors
             var inspector = new VisualElement();
 
             inspector.Add(new PropertyField(serializedObject.FindProperty(sortingOrderBindingPath)));
-            inspector.Add(new PropertyField(serializedObject.FindProperty(targetHandednessBindingPath)));
+
+            if (ShowHandedness)
+            {
+                inspector.Add(new PropertyField(serializedObject.FindProperty(targetHandednessBindingPath)));
+            }
 
             return inspector;
         }

--- a/Editor/Inspectors/InteractionEventsBehaviourInspector.cs
+++ b/Editor/Inspectors/InteractionEventsBehaviourInspector.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityToolkit.Editor.Utilities;
+using RealityToolkit.Input.InteractionBehaviours;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace RealityToolkit.Editor.Inspectors
+{
+    [CustomEditor(typeof(InteractionEventsBehaviour), true)]
+    public class InteractionEventsBehaviourInspector : BaseInteractionBehaviourInspector
+    {
+        /// <summary>
+        /// The events behaviour does not need to display handedness as it will and should
+        /// forward events for any handedness and leave it to the user to decide what to do with it.
+        /// </summary>
+        protected override bool ShowHandedness => false;
+
+        public override VisualElement CreateInspectorGUI()
+        {
+            var inspector = base.CreateInspectorGUI();
+
+            inspector.Add(new PropertyField(serializedObject.FindProperty("firstFocusEntered")));
+            inspector.Add(new PropertyField(serializedObject.FindProperty("focusEntered")));
+            inspector.Add(new PropertyField(serializedObject.FindProperty("focusExited")));
+            inspector.Add(new PropertyField(serializedObject.FindProperty("lastFocusExited")));
+
+            inspector.Add(UIElementsUtilities.VerticalSpace());
+            inspector.Add(new PropertyField(serializedObject.FindProperty("firstSelectEntered")));
+            inspector.Add(new PropertyField(serializedObject.FindProperty("selectEntered")));
+            inspector.Add(new PropertyField(serializedObject.FindProperty("selectExited")));
+            inspector.Add(new PropertyField(serializedObject.FindProperty("lastSelectExited")));
+
+            inspector.Add(UIElementsUtilities.VerticalSpace());
+            inspector.Add(new PropertyField(serializedObject.FindProperty("firstGrabEntered")));
+            inspector.Add(new PropertyField(serializedObject.FindProperty("grabEntered")));
+            inspector.Add(new PropertyField(serializedObject.FindProperty("grabExited")));
+            inspector.Add(new PropertyField(serializedObject.FindProperty("lastGrabExited")));
+
+            inspector.Add(UIElementsUtilities.VerticalSpace());
+            inspector.Add(new PropertyField(serializedObject.FindProperty("reset")));
+
+            return inspector;
+        }
+    }
+}

--- a/Editor/Inspectors/InteractionEventsBehaviourInspector.cs.meta
+++ b/Editor/Inspectors/InteractionEventsBehaviourInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7eabbc8c33ce1a84e9cbc3f03be63d8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Interactables/IInteractable.cs
+++ b/Runtime/Input/Interactables/IInteractable.cs
@@ -68,5 +68,11 @@ namespace RealityToolkit.Input.Interactables
         /// </summary>
         /// <param name="behaviour">The <see cref="IInteractionBehaviour"/>.</param>
         void Remove(IInteractionBehaviour behaviour);
+
+        /// <summary>
+        /// Resets the <see cref="IInteractable"/> and notifies any attached <see cref="IInteractionBehaviour"/>s
+        /// about it using the <see cref="IInteractionBehaviour.OnInteractableReset"/> hook.
+        /// </summary>
+        void ResetInteractable();
     }
 }

--- a/Runtime/Input/Interactables/Interactable.cs
+++ b/Runtime/Input/Interactables/Interactable.cs
@@ -379,6 +379,15 @@ namespace RealityToolkit.Input.Interactables
         /// <inheritdoc/>
         public void Remove(IInteractionBehaviour behaviour) => behaviours.SafeRemoveListItem(behaviour);
 
+        /// <inheritdoc/>
+        public void ResetInteractable()
+        {
+            for (var i = 0; i < behaviours.Count; i++)
+            {
+                behaviours[i].OnInteractableReset();
+            }
+        }
+
         private bool IsValidInteractor(IInteractor interactor) =>
             (interactor.IsFarInteractor && FarInteractionEnabled) || (!interactor.IsFarInteractor && DirectInteractionEnabled);
 

--- a/Runtime/Input/InteractionBehaviours/AutoResetBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/AutoResetBehaviour.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using RealityToolkit.Input.Events;
+using UnityEngine;
+
+namespace RealityToolkit.Input.InteractionBehaviours
+{
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/auto-reset-behaviour")]
+    [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(AutoResetBehaviour))]
+    public class AutoResetBehaviour : BaseInteractionBehaviour
+    {
+        [SerializeField, Tooltip("The delay in seconds after interaction has stopped before the reset will fire.")]
+        private float resetDelay = 5f;
+
+        [SerializeField, Tooltip("If set, the interactable will be reset to its initial pose upon reset.")]
+        private bool resetPose = true;
+
+        private bool didReset;
+        private float interactionStoppedTime;
+        private Pose initialPose;
+
+        /// <inheritdoc/>
+        protected override void Awake()
+        {
+            initialPose = new Pose(transform.position, transform.rotation);
+            base.Awake();
+        }
+
+        /// <inheritdoc/>
+        protected override void OnEnable()
+        {
+            didReset = true;
+            base.OnEnable();
+        }
+
+        /// <inheritdoc/>
+        protected override void Update()
+        {
+            base.Update();
+
+            if (didReset)
+            {
+                return;
+            }
+
+            var timePassed = Time.time - interactionStoppedTime;
+            if (timePassed > resetDelay)
+            {
+                didReset = true;
+                Interactable.ResetInteractable();
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnDisable()
+        {
+            didReset = true;
+            base.OnDisable();
+        }
+
+        /// <inheritdoc/>
+        protected override void OnFocusEntered(InteractionEventArgs eventArgs) => OnInteractionDetected();
+
+        /// <inheritdoc/>
+        protected override void OnLastFocusExited(InteractionExitEventArgs eventArgs)
+        {
+            if (Interactable.IsSelected || Interactable.IsGrabbed)
+            {
+                return;
+            }
+
+            OnInteractionEnded();
+        }
+
+        /// <inheritdoc/>
+        protected override void OnSelectEntered(InteractionEventArgs eventArgs) => OnInteractionDetected();
+
+        /// <inheritdoc/>
+        protected override void OnLastSelectExited(InteractionExitEventArgs eventArgs)
+        {
+            if (Interactable.IsFocused || Interactable.IsGrabbed)
+            {
+                return;
+            }
+
+            OnInteractionEnded();
+        }
+
+        /// <inheritdoc/>
+        protected override void OnGrabEntered(InteractionEventArgs eventArgs) => OnInteractionDetected();
+
+        /// <inheritdoc/>
+        protected override void OnLastGrabExited(InteractionExitEventArgs eventArgs)
+        {
+            if (Interactable.IsSelected || Interactable.IsFocused)
+            {
+                return;
+            }
+
+            OnInteractionEnded();
+        }
+
+        /// <inheritdoc/>
+        protected override void OnResetBehaviour()
+        {
+            didReset = true;
+
+            if (resetPose)
+            {
+                ResetPose();
+            }
+        }
+
+        private void OnInteractionDetected()
+        {
+            didReset = true;
+        }
+
+        private void OnInteractionEnded()
+        {
+            interactionStoppedTime = Time.time;
+            didReset = false;
+        }
+
+        private void ResetPose()
+        {
+            transform.SetPositionAndRotation(initialPose.position, initialPose.rotation);
+        }
+    }
+}

--- a/Runtime/Input/InteractionBehaviours/AutoResetBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/AutoResetBehaviour.cs
@@ -6,6 +6,10 @@ using UnityEngine;
 
 namespace RealityToolkit.Input.InteractionBehaviours
 {
+    /// <summary>
+    /// This <see cref="IInteractionBehaviour"/> will monitor interactions and once ALL interaction on the interactable has ended it will execute a reset
+    /// using the <see cref="Interactables.IInteractable.ResetInteractable"/> API.
+    /// </summary>
     [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/auto-reset-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(AutoResetBehaviour))]
     public class AutoResetBehaviour : BaseInteractionBehaviour

--- a/Runtime/Input/InteractionBehaviours/AutoResetBehaviour.cs.meta
+++ b/Runtime/Input/InteractionBehaviours/AutoResetBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d72ba4b1dceffd04a9ae01f18b791453
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 08c0fd91bdca45afa09ec64323cf3848, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/InteractionBehaviours/BaseInteractionBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/BaseInteractionBehaviour.cs
@@ -12,7 +12,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// <summary>
     /// Base implementation for <see cref="IInteractionBehaviour"/>s.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/custom-behaviours")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/custom-behaviours")]
     [RequireComponent(typeof(Interactable))]
     public abstract class BaseInteractionBehaviour : MonoBehaviour, IInteractionBehaviour
     {
@@ -73,6 +73,12 @@ namespace RealityToolkit.Input.InteractionBehaviours
         /// <see cref="MonoBehaviour"/>.
         /// </summary>
         protected virtual void OnValidate() { }
+
+        /// <inheritdoc/>
+        void IInteractionBehaviour.OnInteractableReset() => OnResetBehaviour();
+
+        /// <inheritdoc cref="IInteractionBehaviour.OnInteractableReset"/>
+        protected virtual void OnResetBehaviour() { }
 
         /// <inheritdoc/>
         void IInteractionBehaviour.OnFirstFocusEntered(InteractionEventArgs eventArgs)

--- a/Runtime/Input/InteractionBehaviours/ButtonBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/ButtonBehaviour.cs
@@ -11,7 +11,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// <summary>
     /// A <see cref="IInteractionBehaviour"/> for creating <see cref="Interactables.IInteractable"/>s that mimick button behaviour.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/button-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/button-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(ButtonBehaviour))]
     public class ButtonBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/ChangeMaterialBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/ChangeMaterialBehaviour.cs
@@ -8,7 +8,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// <summary>
     /// This <see cref="IInteractionBehaviour"/> will change the main material used on a <see cref="MeshRenderer"/> on the <see cref="Interactables.IInteractable"/>.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/change-material-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/change-material-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(ChangeMaterialBehaviour))]
     public class ChangeMaterialBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/FocusHandPoseBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/FocusHandPoseBehaviour.cs
@@ -12,7 +12,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// <summary>
     /// The <see cref="FocusHandPoseBehaviour"/> will animate the <see cref="RiggedHandControllerVisualizer"/>
     /// into the assigned <see cref="focusPose"/>, when the <see cref="Interactables.IInteractable"/> is focused.
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/focus-hand-pose-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/focus-hand-pose-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(FocusHandPoseBehaviour))]
     public class FocusHandPoseBehaviour : BaseInteractionBehaviour, IProvideHandPose
     {

--- a/Runtime/Input/InteractionBehaviours/FocusLockBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/FocusLockBehaviour.cs
@@ -11,7 +11,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// This <see cref="IInteractionBehaviour"/> will focus lock <see cref="IInteractor"/>s on the <see cref="Interactables.IInteractable"/>,
     /// when the <see cref="Interactables.IInteractable.IsSelected"/> or <see cref="Interactables.IInteractable.IsGrabbed"/>.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/focus-lock-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/focus-lock-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(FocusLockBehaviour))]
     public class FocusLockBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/GrabBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/GrabBehaviour.cs
@@ -12,7 +12,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// <see cref="IDirectInteractor"/>s. It allows to "pick up" the <see cref="Interactables.IInteractable"/>
     /// and carry it around.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/grab-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/grab-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(GrabBehaviour))]
     public class GrabBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/GrabHandPoseBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/GrabHandPoseBehaviour.cs
@@ -12,7 +12,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// <summary>
     /// The <see cref="GrabHandPoseBehaviour"/> will animate the <see cref="RiggedHandControllerVisualizer"/>
     /// into the assigned <see cref="grabPose"/>, when the <see cref="Interactables.IInteractable"/> is grabbed.
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/grab-hand-pose-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/grab-hand-pose-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(GrabHandPoseBehaviour))]
     public class GrabHandPoseBehaviour : BaseInteractionBehaviour, IProvideHandPose
     {

--- a/Runtime/Input/InteractionBehaviours/IInteractionBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/IInteractionBehaviour.cs
@@ -23,6 +23,12 @@ namespace RealityToolkit.Input.InteractionBehaviours
         /// </summary>
         IInteractable Interactable { get; }
 
+        /// <summary>
+        /// The <see cref="IInteractable"/> was reset. Use this hook to implement any custom reset
+        /// behaviour your <see cref="IInteractionBehaviour"/> might need to perform when <see cref="IInteractable"/> resets.
+        /// </summary>
+        void OnInteractableReset();
+
         #region Focus
 
         /// <summary>

--- a/Runtime/Input/InteractionBehaviours/InteractionEventsBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/InteractionEventsBehaviour.cs
@@ -3,6 +3,7 @@
 
 using RealityToolkit.Input.Events;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace RealityToolkit.Input.InteractionBehaviours
 {
@@ -18,7 +19,6 @@ namespace RealityToolkit.Input.InteractionBehaviours
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(InteractionEventsBehaviour))]
     public class InteractionEventsBehaviour : BaseInteractionBehaviour
     {
-        [Space]
         [SerializeField]
         private InteractionEvent firstFocusEntered = null;
 
@@ -31,7 +31,6 @@ namespace RealityToolkit.Input.InteractionBehaviours
         [SerializeField]
         private InteractionExitEvent lastFocusExited = null;
 
-        [Space]
         [SerializeField]
         private InteractionEvent firstSelectEntered = null;
 
@@ -44,7 +43,6 @@ namespace RealityToolkit.Input.InteractionBehaviours
         [SerializeField]
         private InteractionExitEvent lastSelectExited = null;
 
-        [Space]
         [SerializeField]
         private InteractionEvent firstGrabEntered = null;
 
@@ -56,6 +54,9 @@ namespace RealityToolkit.Input.InteractionBehaviours
 
         [SerializeField]
         private InteractionExitEvent lastGrabExited = null;
+
+        [SerializeField]
+        private UnityEvent reset = null;
 
         /// <inheritdoc cref="OnFirstFocusEntered(InteractionEventArgs)"/>
         public InteractionEvent FirstFocusEntered => firstFocusEntered;
@@ -93,6 +94,9 @@ namespace RealityToolkit.Input.InteractionBehaviours
         /// <inheritdoc cref="OnLastGrabExited(InteractionExitEventArgs)"/>
         public InteractionExitEvent LastGrabExited => lastGrabExited;
 
+        /// <inheritdoc cref="OnResetBehaviour"/>
+        public UnityEvent Reset => reset;
+
         /// <inheritdoc/>
         protected override void OnFirstFocusEntered(InteractionEventArgs eventArgs) => FirstFocusEntered?.Invoke(eventArgs);
 
@@ -128,5 +132,8 @@ namespace RealityToolkit.Input.InteractionBehaviours
 
         /// <inheritdoc/>
         protected override void OnLastGrabExited(InteractionExitEventArgs eventArgs) => LastGrabExited?.Invoke(eventArgs);
+
+        /// <inheritdoc/>
+        protected override void OnResetBehaviour() => Reset?.Invoke();
     }
 }

--- a/Runtime/Input/InteractionBehaviours/InteractionEventsBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/InteractionEventsBehaviour.cs
@@ -14,7 +14,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// <remarks>
     /// Consider implementing a custom <see cref="BaseInteractionBehaviour"/> instead.
     /// </remarks>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/interaction-events-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/interaction-events-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(InteractionEventsBehaviour))]
     public class InteractionEventsBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/LeverBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/LeverBehaviour.cs
@@ -14,7 +14,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// simulate all kinds of levers the user can interacth with.
     /// </summary>
     [ExecuteInEditMode]
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/lever-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/lever-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(LeverBehaviour))]
     public class LeverBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
@@ -19,7 +19,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// Only supports <see cref="IControllerInteractor"/>s.
     /// Does not support <see cref="IPokeInteractor"/>s and will ignore them.
     /// </remarks>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/lock-controller-visualizer-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/lock-controller-visualizer-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(LockControllerVisualizerBehaviour))]
     public class LockControllerVisualizerBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/PokeResponseBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/PokeResponseBehaviour.cs
@@ -13,7 +13,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// A <see cref="IInteractionBehaviour"/> that will translate a given <see cref="Transform"/>
     /// in response to being poked by a <see cref="IPokeInteractor"/>.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/poke-response-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/poke-response-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(PokeResponseBehaviour))]
     public class PokeResponseBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/SelectHandPoseBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/SelectHandPoseBehaviour.cs
@@ -9,7 +9,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// <summary>
     /// The <see cref="SelectHandPoseBehaviour"/> will animate the <see cref="RiggedHandControllerVisualizer"/>
     /// into the assigned <see cref="selectPose"/>, when the <see cref="Interactables.IInteractable"/> is selected.
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/select-hand-pose-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/select-hand-pose-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(SelectHandPoseBehaviour))]
     public class SelectHandPoseBehaviour : BaseInteractionBehaviour, IProvideHandPose
     {

--- a/Runtime/Input/InteractionBehaviours/SteeringWheelBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/SteeringWheelBehaviour.cs
@@ -14,7 +14,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// Use this <see cref="IInteractionBehaviour"/> to make an <see cref="Interactables.IInteractable"/> behave like
     /// a steering wheel.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/steering-wheel-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/steering-wheel-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(SteeringWheelBehaviour))]
     public class SteeringWheelBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/ToggleBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/ToggleBehaviour.cs
@@ -11,7 +11,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// <summary>
     /// A <see cref="IInteractionBehaviour"/> for creating <see cref="Interactables.IInteractable"/>s that mimick toggle button behaviour.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/toggle-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/toggle-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(ToggleBehaviour))]
     public class ToggleBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/TranslateBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/TranslateBehaviour.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace RealityToolkit.Input.InteractionBehaviours
 {
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/translate-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/translate-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(TranslateBehaviour))]
     public class TranslateBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/Input/InteractionBehaviours/UpdateRigidbodyBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/UpdateRigidbodyBehaviour.cs
@@ -10,7 +10,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
     /// This <see cref="IInteractionBehaviour"/> will update the <see cref="Rigidbody"/> on the <see cref="Interactables.IInteractable"/>
     /// when interacted with.
     /// </summary>
-    [HelpURL("https://www.realitytoolkit.io/docs/interactions/interaction-behaviours/default-behaviours/update-rigidbody-behaviour")]
+    [HelpURL(RealityToolkitRuntimePreferences.Toolkit_Docs_BaseUrl + "docs/interactions/interaction-behaviours/default-behaviours/update-rigidbody-behaviour")]
     [AddComponentMenu(RealityToolkitRuntimePreferences.Toolkit_InteractionsAddComponentMenu + "/" + nameof(UpdateRigidbodyBehaviour))]
     public class UpdateRigidbodyBehaviour : BaseInteractionBehaviour
     {

--- a/Runtime/RealityToolkitRuntimePreferences.cs
+++ b/Runtime/RealityToolkitRuntimePreferences.cs
@@ -14,6 +14,11 @@ namespace RealityToolkit
         public const string Toolkit_AddComponentMenu = "Reality Toolkit";
 
         /// <summary>
+        /// The top level domain of the toolkit docs website.
+        /// </summary>
+        public const string Toolkit_Docs_BaseUrl = "https://realitytoolkit.realitycollective.net/";
+
+        /// <summary>
         /// The top level interactions menu group for the add component menu.
         /// </summary>
         public const string Toolkit_InteractionsAddComponentMenu = Toolkit_AddComponentMenu + "/" + "Interactions";


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

It is a common scenario that we want to reset or clean up an interactable after the user is done interacting with it. When such  a reset occurs, all interaction behaviours on the interactable must rest, if applicable.

- A new `IInteractable.ResetInteractable` API was introduced. This API will ask the interactable to perform a full reset and will make sure all `IInteractionBehaviours` attached to it, will receive a notification to do so as well.

- A new `AutoResetBehaviour` has been added. This interaction behaviour will monitor interactions and once ALL interaction on the interactable have ended, it will execute a reset after a configurable amount of time. It also comes with an option to auto reset the interactable to its initial pose.

- A new "Reset" event has been exposed for third party scripts or the Unity editor to hook into when a reset happens

- Updated all the docs help URLs to the new domain

- Added a way to hide the target handedness setting in the inspector for behaviours that ignore that setting