### PR TITLE
Fix pose unlock smooths in wrong coordinate space

### DIFF
--- a/Runtime/Input/Controllers/BaseController.cs
+++ b/Runtime/Input/Controllers/BaseController.cs
@@ -196,8 +196,7 @@ namespace RealityToolkit.Input.Controllers
                 return;
             }
 
-            var rigTransform = Camera.main.transform.parent;
-
+            var rigTransform = InputService.InputRig.RigTransform;
             var controllerObject = Object.Instantiate(controllerPrefab, rigTransform);
             controllerObject.name = GetType().Name;
             Visualizer = controllerObject.GetComponent<IControllerVisualizer>();
@@ -241,6 +240,28 @@ namespace RealityToolkit.Input.Controllers
             {
                 Debug.LogError($"{GetType().Name} prefab must have a {nameof(IControllerVisualizer)} component attached.");
             }
+        }
+
+        /// <inheritdoc />
+        public bool TryGetPose(Space space, out Pose pose)
+        {
+            if (!IsPositionAvailable || !IsRotationAvailable)
+            {
+                pose = default;
+                return false;
+            }
+
+            if (space == Space.Self)
+            {
+                pose = Pose;
+                return true;
+            }
+
+            pose = new Pose(
+                InputService.InputRig.RigTransform.TransformPoint(Pose.position),
+                InputService.InputRig.RigTransform.rotation * Pose.rotation);
+
+            return true;
         }
     }
 }

--- a/Runtime/Input/Controllers/BaseControllerVisualizer.cs
+++ b/Runtime/Input/Controllers/BaseControllerVisualizer.cs
@@ -22,9 +22,6 @@ namespace RealityToolkit.Input.Controllers
         public GameObject GameObject => gameObject;
 
         /// <inheritdoc />
-        public Pose SourcePose { get; private set; }
-
-        /// <inheritdoc />
         public bool OverrideSourcePose { get; set; }
 
         /// <inheritdoc />

--- a/Runtime/Input/Controllers/BaseControllerVisualizer.cs
+++ b/Runtime/Input/Controllers/BaseControllerVisualizer.cs
@@ -44,11 +44,6 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Pose> eventData)
         {
-            if (eventData.SourceId == Controller?.InputSource.SourceId)
-            {
-                SourcePose = eventData.SourceData;
-            }
-
             if (OverrideSourcePose)
             {
                 return;
@@ -60,11 +55,6 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Quaternion> eventData)
         {
-            if (eventData.SourceId == Controller?.InputSource.SourceId)
-            {
-                SourcePose = new Pose(SourcePose.position, eventData.SourceData);
-            }
-
             if (OverrideSourcePose)
             {
                 return;
@@ -76,11 +66,6 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Vector2> eventData)
         {
-            if (eventData.SourceId == Controller?.InputSource.SourceId)
-            {
-                SourcePose = new Pose(eventData.SourceData, SourcePose.rotation);
-            }
-
             if (OverrideSourcePose)
             {
                 return;
@@ -92,11 +77,6 @@ namespace RealityToolkit.Input.Controllers
         /// <inheritdoc />
         public override void OnSourcePoseChanged(SourcePoseEventData<Vector3> eventData)
         {
-            if (eventData.SourceId == Controller?.InputSource.SourceId)
-            {
-                SourcePose = new Pose(eventData.SourceData, SourcePose.rotation);
-            }
-
             if (OverrideSourcePose)
             {
                 return;

--- a/Runtime/Input/Controllers/IController.cs
+++ b/Runtime/Input/Controllers/IController.cs
@@ -108,5 +108,14 @@ namespace RealityToolkit.Input.Controllers
         /// Updates the <see cref="IController"/>'s state.
         /// </summary>
         void UpdateController();
+
+        /// <summary>
+        /// Attempts to retrieve the <see cref="IController"/>'s pose in the scene in either the local space,
+        /// that is in the <see cref="IInputRig.RigTransform"/> space or in world space.
+        /// </summary>
+        /// <param name="space">The space to get the <see cref="UnityEngine.Pose"/> in.</param>
+        /// <param name="pose">The pose.</param>
+        /// <returns><c>true</c>, if found Will return <c>false</c>, if not <see cref="IsPositionAvailable"/> or <see cref="IsRotationAvailable"/>.</returns>
+        bool TryGetPose(Space space, out Pose pose);
     }
 }

--- a/Runtime/Input/Controllers/IControllerVisualizer.cs
+++ b/Runtime/Input/Controllers/IControllerVisualizer.cs
@@ -19,12 +19,6 @@ namespace RealityToolkit.Input.Controllers
         GameObject GameObject { get; }
 
         /// <summary>
-        /// This is the actual pose of this controller, regardless of <see cref="OverrideSourcePose"/>
-        /// and the <see cref="IControllerPoseSynchronizer.PoseDriver"/> pose.
-        /// </summary>
-        Pose SourcePose { get; }
-
-        /// <summary>
         /// If set, the <see cref="IControllerPoseSynchronizer.PoseDriver"/>'s pose in the scene
         /// is override and the actual <see cref="IController.InputSource"/> pose is ignored.
         /// </summary>

--- a/Runtime/Input/Cursors/MeshCursor.cs
+++ b/Runtime/Input/Cursors/MeshCursor.cs
@@ -62,11 +62,11 @@ namespace RealityToolkit.Input.Cursors
             if (targetRenderer == null) { return; }
 
             var targetTransform = targetRenderer.transform;
-            var targetCamera = Camera.main;
+            var targetCamera = InputService.InputRig.CameraTransform;
 
             var cameraPosition = targetCamera.transform.position;
             var distance = (cameraPosition - targetTransform.position).magnitude;
-            var size = distance * fixedSize * targetCamera.fieldOfView;
+            var size = distance * fixedSize * InputService.InputRig.RigCamera.fieldOfView;
 
             targetTransform.localScale = Vector3.one * size;
             targetTransform.localPosition = new Vector3(fixedSizeOffset.x * size, fixedSizeOffset.y * size, fixedSizeOffset.z * size);

--- a/Runtime/Input/Hands/HandController.cs
+++ b/Runtime/Input/Hands/HandController.cs
@@ -788,10 +788,10 @@ namespace RealityToolkit.Input.Hands
                 };
 
                 // Translate to world space.
-                if (Camera.main.transform.parent.IsNotNull())
+                if (InputService.InputRig.RigTransform.IsNotNull())
                 {
-                    pose.position = Camera.main.transform.parent.TransformPoint(pose.position);
-                    pose.rotation = Camera.main.transform.parent.rotation * pose.rotation;
+                    pose.position = InputService.InputRig.RigTransform.TransformPoint(pose.position);
+                    pose.rotation = InputService.InputRig.RigTransform.rotation * pose.rotation;
                 }
 
                 return lastHandRootPose != Pose.identity;

--- a/Runtime/Input/Hands/HandDataPostProcessor.cs
+++ b/Runtime/Input/Hands/HandDataPostProcessor.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Reality Collective. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using RealityCollective.ServiceFramework.Services;
 using RealityCollective.Utilities.Extensions;
 using RealityToolkit.Definitions.Devices;
 using RealityToolkit.Input.Definitions;
 using RealityToolkit.Input.Hands.Poses;
+using RealityToolkit.Input.Interfaces;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -38,9 +40,9 @@ namespace RealityToolkit.Input.Hands
         {
             get
             {
-                if (playerCamera == null)
+                if (playerCamera.IsNull())
                 {
-                    playerCamera = Camera.main;
+                    playerCamera = ServiceManager.Instance.GetService<IInputService>().InputRig.RigCamera;
                 }
 
                 return playerCamera;

--- a/Runtime/Input/InputService.cs
+++ b/Runtime/Input/InputService.cs
@@ -70,6 +70,9 @@ namespace RealityToolkit.Input
         /// <inheritdoc/>
         public bool FarInteractionEnabled { get; set; }
 
+        /// <inheritdoc/>
+        public IInputRig InputRig { get; set; }
+
         private readonly HashSet<IInputSource> detectedInputSources = new HashSet<IInputSource>();
 
         /// <inheritdoc />

--- a/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
@@ -60,7 +60,7 @@ namespace RealityToolkit.Input.InteractionBehaviours
                         continue;
                     }
 
-                    var unlockPose = visualizer.SourcePose;
+                    var unlockPose = visualizer.Controller.Pose;
                     unlockPose.position = Vector3.Slerp(smoothingStartPose[visualizer].position, unlockPose.position, smoothingProgress[visualizer]);
                     unlockPose.rotation = Quaternion.Slerp(smoothingStartPose[visualizer].rotation, unlockPose.rotation, smoothingProgress[visualizer]);
                     visualizer.PoseDriver.SetPositionAndRotation(unlockPose.position, unlockPose.rotation);

--- a/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
+++ b/Runtime/Input/InteractionBehaviours/LockControllerVisualizerBehaviour.cs
@@ -60,10 +60,12 @@ namespace RealityToolkit.Input.InteractionBehaviours
                         continue;
                     }
 
-                    var unlockPose = visualizer.Controller.Pose;
-                    unlockPose.position = Vector3.Slerp(smoothingStartPose[visualizer].position, unlockPose.position, smoothingProgress[visualizer]);
-                    unlockPose.rotation = Quaternion.Slerp(smoothingStartPose[visualizer].rotation, unlockPose.rotation, smoothingProgress[visualizer]);
-                    visualizer.PoseDriver.SetPositionAndRotation(unlockPose.position, unlockPose.rotation);
+                    if (visualizer.Controller.TryGetPose(Space.World, out var unlockPose))
+                    {
+                        unlockPose.position = Vector3.Slerp(smoothingStartPose[visualizer].position, unlockPose.position, smoothingProgress[visualizer]);
+                        unlockPose.rotation = Quaternion.Slerp(smoothingStartPose[visualizer].rotation, unlockPose.rotation, smoothingProgress[visualizer]);
+                        visualizer.PoseDriver.SetPositionAndRotation(unlockPose.position, unlockPose.rotation);
+                    }
                 }
                 else
                 {

--- a/Runtime/Input/Interfaces/IInputRig.cs
+++ b/Runtime/Input/Interfaces/IInputRig.cs
@@ -20,5 +20,10 @@ namespace RealityToolkit.Input.Interfaces
         /// The <see cref="Transform"/> where the <see cref="Camera"/> component is located.
         /// </summary>
         Transform CameraTransform { get; }
+
+        /// <summary>
+        /// The rig's <see cref="Camera"/> reference.
+        /// </summary>
+        Camera RigCamera { get; }
     }
 }

--- a/Runtime/Input/Interfaces/IInputRig.cs
+++ b/Runtime/Input/Interfaces/IInputRig.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Reality Collective. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEngine;
+
+namespace RealityToolkit.Input.Interfaces
+{
+    /// <summary>
+    /// The <see cref="IInputRig"/> defines the coordinate space in which <see cref="IInputService"/> objects, such as
+    /// <see cref="IInputSource"/>s live. It is used to perform pose transformations for controllers, visualizers and interactors.
+    /// </summary>
+    public interface IInputRig
+    {
+        /// <summary>
+        /// The root rig <see cref="Transform"/>.
+        /// </summary>
+        Transform RigTransform { get; }
+
+        /// <summary>
+        /// The <see cref="Transform"/> where the <see cref="Camera"/> component is located.
+        /// </summary>
+        Transform CameraTransform { get; }
+    }
+}

--- a/Runtime/Input/Interfaces/IInputRig.cs.meta
+++ b/Runtime/Input/Interfaces/IInputRig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf2c6272f41e68b40b2f4ae7d21c2c09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ac5213854cf4dbabd140decf8df1946, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Input/Interfaces/IInputService.cs
+++ b/Runtime/Input/Interfaces/IInputService.cs
@@ -41,6 +41,11 @@ namespace RealityToolkit.Input.Interfaces
         bool FarInteractionEnabled { get; set; }
 
         /// <summary>
+        /// The active <see cref="IInputRig"/> the <see cref="IInputService"/> is using.
+        /// </summary>
+        IInputRig InputRig { get; set; }
+
+        /// <summary>
         /// List of the Interaction Input Sources as detected by the input manager like hands or motion controllers.
         /// </summary>
         IReadOnlyCollection<IInputSource> DetectedInputSources { get; }


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

- Turns out the source pose reported to the `IControllerPoseSynchronizer` is in the rigs local space and not world space. This caused issues when smoothing the visualizer pose from the interactable lock pose to the actual controller pose when the player rig is not located at the scene origin. Also I realized we do not need an extra `IControllerVisualizer.SourcePose` property that was recently introduced, since we can simply use `IControllerVisualizer.Controller.Pose` for that

- Introduced `IInputRig`. Same concept as with the locomotion service. The input service expects an `IInputRig` to be available in the scene so the input service components, such as controllers, can work. The toolkit's player package is a first party citizen and comes with an out of the box input rig, which is the player rig itself. If, for whatever reason, someone decides to use the input service without the player package, then they have to make sure to register the `IInputRig` manually using their own implementation. This is a very advanced use case scenario though. For testing I have already replaced some of the `Camera.main` references in the core module using the new `InputService.InputRig` API. I'll do another PR updating the rest. Resolves https://github.com/realitycollective/com.realitytoolkit.core/issues/77